### PR TITLE
Add apikey to all endpoints

### DIFF
--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -115,6 +115,8 @@ paths:
                 message: "Session could not be created"
         "503":
           $ref: "#/components/responses/Generic503"
+      security:
+        - apiKey: []
   /sessions/{sessionId}:
     get:
       tags:
@@ -143,6 +145,8 @@ paths:
           $ref: "#/components/responses/SessionNotFound404"
         "503":
           $ref: "#/components/responses/Generic503"
+      security:
+        - apiKey: []
     delete:
       tags:
         - QoS sessions
@@ -166,6 +170,8 @@ paths:
           $ref: "#/components/responses/SessionNotFound404"
         "503":
           $ref: "#/components/responses/Generic503"
+      security:
+        - apiKey: []
   /notifications:
     post:
       tags:


### PR DESCRIPTION
We are using the Flask [Connexion](https://connexion.readthedocs.io/en/latest/) framework to develop a demo using this API, but it does not function properly without a security implementation defined for all endpoints.