### PR TITLE
Purposal: Add paginated get list endpoint

### DIFF
--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -244,20 +244,6 @@ components:
       type: string
       format: uuid
       description: Session ID in UUID format
-    SessionInfos:
-      description: Paged response of created sessions
-      type: object
-      properties:
-        pageSize:
-          description: count of sessions in response
-          type: integer
-        pageNumber:
-          description: currently selected page number
-          type: integer
-        sessions:
-          description: Array of sessions to be returned.
-          type: array
-          $ref: "#/components/schemas/SessionInfo"
     SessionInfo:
       description: Session related information.
       allOf:
@@ -285,6 +271,22 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/Message"
+    SessionInfos:
+      description: Paged response of created sessions
+      type: object
+      properties:
+        pageSize:
+          description: count of sessions in response
+          type: integer
+        pageNumber:
+          description: currently selected page number
+          type: integer
+        sessions:
+          description: Array of sessions to be returned.
+          type: array
+          items:
+            type: object
+            $ref: "#/components/schemas/SessionInfo"
     CreateSession:
       description: Data type with attributes required for creating a session
       type: object

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -115,6 +115,54 @@ paths:
                 message: "Session could not be created"
         "503":
           $ref: "#/components/responses/Generic503"
+    get:
+      tags:
+        - QoS Sessions
+      summary: Fetch all paginated sessions created
+      description: Fetch QoS sessions created
+      operationId: listSessions
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: interger
+          required: true
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 10
+      responses:
+        "200":
+          description: Sessions page listed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionInfos"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorInfo"
+              example:
+                code: CONFLICT
+                message: "Another session is created for the same UE"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorInfo"
+              example:
+                code: INTERNAL
+                message: "Session could not be created"
+        "503":
+          $ref: "#/components/responses/Generic503"
   /sessions/{sessionId}:
     get:
       tags:
@@ -214,6 +262,20 @@ components:
       type: string
       format: uuid
       description: Session ID in UUID format
+    SessionInfos:
+      description: Paged response of created sessions
+      type: object
+      properties:
+        pageSize:
+          description: count of sessions in response
+          type: integer
+        pageNumber:
+          description: currently selected page number
+          type: integer
+        sessions:
+          description: Array of sessions to be returned.
+          type: array
+          $ref: "#/components/schemas/SessionInfo"
     SessionInfo:
       description: Session related information.
       allOf:

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -117,21 +117,21 @@ paths:
           $ref: "#/components/responses/Generic503"
     get:
       tags:
-        - QoS Sessions
-      summary: Fetch all paginated sessions created
+        - QoS sessions
+      summary: Get all session information
       description: Fetch QoS sessions created
       operationId: listSessions
       parameters:
         - in: query
           name: page
           schema:
-            type: interger
+            type: integer
           required: true
         - in: query
           name: pageSize
           schema:
             type: integer
-            default: 10
+            default: 100
       responses:
         "200":
           description: Sessions page listed

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -143,24 +143,6 @@ paths:
           $ref: "#/components/responses/Generic401"
         "403":
           $ref: "#/components/responses/Generic403"
-        "409":
-          description: Conflict
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorInfo"
-              example:
-                code: CONFLICT
-                message: "Another session is created for the same UE"
-        "500":
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorInfo"
-              example:
-                code: INTERNAL
-                message: "Session could not be created"
         "503":
           $ref: "#/components/responses/Generic503"
   /sessions/{sessionId}:


### PR DESCRIPTION
Page through all existing sessions currently active for the authenticated user.

Example usage:

`curl  --request GET 'http://localhost:9091/qod/v0/sessions?page=1'`
(`pageSize` is an optional parameter and can be used to change the number of sessions returned)