### PR TITLE
Modify create session url name and add a complimentary description for qos in api definition 

### DIFF
--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -1,11 +1,12 @@
-| Org                    | Name                                                |
-| -----------------------| ----------------------------------------------------|
-| Deutsche Telekom AG | Herbert Damker |
-| Ericsson | Emil Zhang |
-| Orange | Sylvain Morel |
-| Telefonica | Jose Luis Urien |
-| Telefonica | Jesus Peña| 
-| Vodafone | Eric Murray |
-| Verizon/ 5GFF| Syed Rehman |
-| Verizon/ 5GFF| Mahesh Chapalamadugu |
-| KDDI | Toshi (Toshiyasu) Wakayama |
+| Org                 | Name                       |
+|---------------------|----------------------------|
+| Deutsche Telekom AG | Herbert Damker             |
+| Ericsson            | Emil Zhang                 |
+| Huawei              | Shuting Qing               |
+| Orange              | Sylvain Morel              |
+| Telefonica          | Jose Luis Urien            |
+| Telefonica          | Jesus Peña                 | 
+| Vodafone            | Eric Murray                |
+| Verizon/ 5GFF       | Syed Rehman                |
+| Verizon/ 5GFF       | Mahesh Chapalamadugu       |
+| KDDI                | Toshi (Toshiyasu) Wakayama |

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -24,7 +24,7 @@ servers:
         default: qod/v0
         description: Base path for the QoD API
 paths:
-  /sessions:
+  /createSessions:
     post:
       tags:
         - QoS sessions
@@ -336,10 +336,11 @@ components:
         - QOS_M
         - QOS_L
       description: |
-        * `QOS_E` - Qualifier for enhanced communication profile
-        * `QOS_S` - Qualifier for the requested QoS profile _S_
-        * `QOS_M` - Qualifier for the requested QoS profile _M_
-        * `QOS_L` - Qualifier for the requested QoS profile _L_
+        *  For more details, please check API documentation QoSProfile_Mapping_Table.md.
+        * `QOS_E` - Qualifier for enhanced communication profile. Latency stays stable under congestion (throughput up to a certain limit, e.g. 500kbps). 
+        * `QOS_S` - Qualifier for the requested QoS profile _S_ . The 5G System throughput is prioritized up to certain higher limit (e.g. 20Mbps), or without an explicit limit. 
+        * `QOS_M` - Qualifier for the requested QoS profile _M_ . The 5G System throughput is prioritized up to certain medium limit (e.g. 8Mbps). 
+        * `QOS_L` - Qualifier for the requested QoS profile _L_ . The 5G System throughput is prioritized up to certain lower limit (e.g. 4Mbps). 
     
     Notification:
       type: object
@@ -535,7 +536,7 @@ components:
             $ref: "#/components/schemas/ErrorInfo"
           example:
             status: 500
-            code: INTERNAL
+            code: INTERNAL_ERROR
             message: "Internal server error: ..."
     Generic501:
       description: Not Implemented


### PR DESCRIPTION
#### What type of PR is this?
* documentation

#### What this PR does / why we need it:
From developer perspective, when  i look into the api definitions, i may have some suggestions.

1. For the create session url,  currently it's '/sessions' why not use ‘createSessions’ directly？How do you guys feel?
2. For the QoS profile, through it's been clarified very clearly in documentations, but i'll suggest a brief description of qos_e qos_l qos_m qos_s is required. So people can easily know. 
3. Delete useless .gitignore file.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
