### PR TITLE
Add oauth authorizationCode security to sensible endpoints

### DIFF
--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -130,6 +130,11 @@ paths:
           $ref: "#/components/responses/Generic501"
         "503":
           $ref: "#/components/responses/Generic503"
+      security:
+        - oAuth2ClientCredentials: []
+        - threeLegged:
+          - "qod-sessions-write"
+      
   /sessions/{sessionId}:
     get:
       tags:
@@ -160,6 +165,11 @@ paths:
           $ref: "#/components/responses/Generic500"
         "503":
           $ref: "#/components/responses/Generic503"
+      security:
+        - oAuth2ClientCredentials: []
+        - threeLegged:
+          - "qod-sessions-read"
+
     delete:
       tags:
         - QoS sessions
@@ -185,6 +195,11 @@ paths:
           $ref: "#/components/responses/Generic500"
         "503":
           $ref: "#/components/responses/Generic503"
+      security:
+        - oAuth2ClientCredentials: []
+        - threeLegged:
+          - "qod-sessions-delete"
+      
   /notifications:
     post:
       tags:
@@ -256,6 +271,7 @@ paths:
           $ref: "#/components/responses/QoSProfile500"
         "503":
           $ref: "#/components/responses/Generic503"
+
   /qos-profiles/{name}:
     get:
       tags:
@@ -289,6 +305,7 @@ paths:
           $ref: "#/components/responses/QoSProfile500"
         "503":
           $ref: "#/components/responses/Generic503"
+
 components:
   securitySchemes:
     oAuth2ClientCredentials:
@@ -298,6 +315,18 @@ components:
         clientCredentials:
           tokenUrl: "{tokenUrl}"
           scopes: {}
+    threeLegged:
+      type: oauth2
+      description: This API uses OAuth 2 with the authorization code grant flow.
+      flows:
+        authorizationCode:
+          authorizationUrl: "{authorizationUrl}"
+          tokenUrl: "{tokenUrl}"
+          scopes:
+            qod-sessions-read: Retrieval of QoS sessions
+            qod-sessions-write: Creation and update of QoS sessions
+            qod-sessions-delete: Deletion of QoS sessions
+            qod-profiles-read: Retrieval of QoS profiles
     apiKey:
       type: apiKey
       description: API key to authorize requests


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

- Adds the option to use security oauth2 authorizationCode flow to the endpoints dealing with QoD sessions, as in some cases they may require user consent, and define scopes for those endpoints. 

- The new endpoints for QoS Profiles discovery are left with previous security (clientCredentials)

#### Which issue(s) this PR fixes:

Fixes #161 

#### Special notes for reviewers:

For the short term, I followed the same approach that is used in other WGs with client credentials and 3-legged coexistence, but we will probably need to review the topic in Commonalities or Identity WG, as there is a lack of coherence among different WGs. For example, currently scopes are not defined for OAuth2 Client credentials, in some WGs openidconnect is used instead of oauth2, etc

#### Changelog input

```
- Scopes specified and OAuth2 authorizationCode flow added as security mechanism, for operations dealing with QoD sessions

```

#### Additional documentation 

---



```
docs

```
