### PR TITLE
fix(openapi): Add inheritance beetween Event and QosStatusChangedEvent

### DIFF
--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -742,7 +742,17 @@ components:
         eventSubscriptionId:
           type: string
           description: 'The ID of explicit subscription or none in case of implicit subscription'
-          example: '7698d710-98b7-4695-a958-7b228f08128c'
+      example:
+        {
+          "eventId": "5698d710-9b1b-4695-a958-7b228f08128c",
+          "eventType": "QOS_STATUS_CHANGED",
+          "eventTime": "2023-05-30T10:18:28Z",
+          "eventDetail": {
+            "sessionId": "7698d710-98b7-4695-a958-7b228f08128c",
+            "qosStatus": "UNAVAILABLE",
+            "statusInfo": "DURATION_EXPIRED"
+          }
+        }
 
     Event:
       description: The event being notified

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -749,6 +749,17 @@ components:
         propertyName: eventType
         mapping:
           QOS_STATUS_CHANGED: "#/components/schemas/QosStatusChangedEvent"
+      example:
+        {
+          "eventId": "5698d710-9b1b-4695-a958-7b228f08128c",
+          "eventType": "QOS_STATUS_CHANGED",
+          "eventTime": "2023-05-30T10:18:28Z",
+          "eventDetail": {
+            "sessionId": "7698d710-98b7-4695-a958-7b228f08128c",
+            "qosStatus": "UNAVAILABLE",
+            "statusInfo": "DURATION_EXPIRED"
+          }
+        }
 
     EventId:
       type: string
@@ -797,7 +808,7 @@ components:
           type: string
           enum:
             - DURATION_EXPIRED
-            - NETWORK_TERMINATED¡
+            - NETWORK_TERMINATED
 
     Device:
       description: |

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -739,7 +739,7 @@ components:
       properties:
         event:
           $ref: "#/components/schemas/Event"
-        subscriptionId:
+        eventSubscriptionId:
           type: string
           description: 'The ID of explicit subscription or none in case of implicit subscription'
           example: '7698d710-98b7-4695-a958-7b228f08128c'

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -113,7 +113,7 @@ paths:
                 content:
                   application/json:
                     schema:
-                      $ref: "#/components/schemas/EventNotification"
+                      $ref: "#/components/schemas/Event"
               responses:
                 "204":
                   description: Successful notification
@@ -400,34 +400,34 @@ components:
 
     SessionInfo:
       description: Session related information.
+      type: object
       allOf:
         - $ref: "#/components/schemas/CreateSession"
-        - type: object
-          properties:
-            sessionId:
-              $ref: "#/components/schemas/SessionId"
-            startedAt:
-              type: integer
-              example: 1639479600
-              description: Timestamp of session start in seconds since Unix epoch
-              format: int64
-            expiresAt:
-              type: integer
-              example: 1639566000
-              description: Timestamp of session expiration if the session was not deleted, in seconds since Unix epoch
-              format: int64
-            qosStatus:
-              $ref: "#/components/schemas/QosStatus"
-            messages:
-              type: array
-              items:
-                $ref: "#/components/schemas/Message"
-          required:
-            - sessionId
-            - duration
-            - startedAt
-            - expiresAt
-            - qosStatus
+      properties:
+        sessionId:
+          $ref: "#/components/schemas/SessionId"
+        startedAt:
+          type: integer
+          example: 1639479600
+          description: Timestamp of session start in seconds since Unix epoch
+          format: int64
+        expiresAt:
+          type: integer
+          example: 1639566000
+          description: Timestamp of session expiration if the session was not deleted, in seconds since Unix epoch
+          format: int64
+        qosStatus:
+          $ref: "#/components/schemas/QosStatus"
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Message"
+      required:
+        - sessionId
+        - duration
+        - startedAt
+        - expiresAt
+        - qosStatus
 
     CreateSession:
       description: Attributes required to create a session
@@ -699,7 +699,7 @@ components:
           allOf:
             - $ref: "#/components/schemas/TimeUnitEnum"
             - example: Minutes
-            
+
     TimeUnitEnum:
       type: string
       enum:
@@ -732,18 +732,19 @@ components:
         - Gbps
         - Tbps
 
-    EventNotification:
-      type: object
-      required:
-        - event
-      properties:
-        event:
-          $ref: "#/components/schemas/Event"
-
     Event:
       description: The event being notified
-      anyOf:
-        - $ref: "#/components/schemas/QosStatusChangedEvent"
+      type: object
+      required:
+        - eventType
+        - eventTime
+      properties:
+        eventid:
+          $ref: "#/components/schemas/EventId"
+        eventType:
+          $ref: "#/components/schemas/EventType"
+        eventTime:
+          $ref: "#/components/schemas/EventTime"
       discriminator:
         propertyName: eventType
         mapping:
@@ -767,39 +768,26 @@ components:
       example: 2023-05-30T10:18:28Z
       description: Date time when the event occurred
 
-    EventBase:
-      type: object
-      required:
-        - eventType
-        - eventTime
-      properties:
-        eventid:
-          $ref: "#/components/schemas/EventId"
-        eventType:
-          $ref: "#/components/schemas/EventType"
-        eventTime:
-          $ref: "#/components/schemas/EventTime"
-
     QosStatusChangedEvent:
+      type: object
       allOf:
-        - $ref: "#/components/schemas/EventBase"
-        - type: object
-          properties:
-            eventDetail:
-              type: object
-              description: Event details depending on the event type
-              required:
-                - sessionId
-                - qosStatus
-              properties:
-                sessionId:
-                  $ref: "#/components/schemas/SessionId"
-                qosStatus:
-                  $ref: "#/components/schemas/EventQosStatus"
-                statusInfo:
-                  $ref: "#/components/schemas/StatusInfo"
+        - $ref: "#/components/schemas/Event"
+      properties:
+        eventDetail:
+          type: object
+          description: Event details depending on the event type
           required:
-          - eventDetail
+            - sessionId
+            - qosStatus
+          properties:
+            sessionId:
+              $ref: "#/components/schemas/SessionId"
+            qosStatus:
+              $ref: "#/components/schemas/EventQosStatus"
+            statusInfo:
+              $ref: "#/components/schemas/StatusInfo"
+      required:
+        - eventDetail
 
     StatusInfo:
           description: |

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -400,34 +400,34 @@ components:
 
     SessionInfo:
       description: Session related information.
-      type: object
       allOf:
         - $ref: "#/components/schemas/CreateSession"
-      properties:
-        sessionId:
-          $ref: "#/components/schemas/SessionId"
-        startedAt:
-          type: integer
-          example: 1639479600
-          description: Timestamp of session start in seconds since Unix epoch
-          format: int64
-        expiresAt:
-          type: integer
-          example: 1639566000
-          description: Timestamp of session expiration if the session was not deleted, in seconds since Unix epoch
-          format: int64
-        qosStatus:
-          $ref: "#/components/schemas/QosStatus"
-        messages:
-          type: array
-          items:
-            $ref: "#/components/schemas/Message"
-      required:
-        - sessionId
-        - duration
-        - startedAt
-        - expiresAt
-        - qosStatus
+        - type: object
+          properties:
+            sessionId:
+              $ref: "#/components/schemas/SessionId"
+            startedAt:
+              type: integer
+              example: 1639479600
+              description: Timestamp of session start in seconds since Unix epoch
+              format: int64
+            expiresAt:
+              type: integer
+              example: 1639566000
+              description: Timestamp of session expiration if the session was not deleted, in seconds since Unix epoch
+              format: int64
+            qosStatus:
+              $ref: "#/components/schemas/QosStatus"
+            messages:
+              type: array
+              items:
+                $ref: "#/components/schemas/Message"
+          required:
+            - sessionId
+            - duration
+            - startedAt
+            - expiresAt
+            - qosStatus
 
     CreateSession:
       description: Attributes required to create a session
@@ -769,25 +769,25 @@ components:
       description: Date time when the event occurred
 
     QosStatusChangedEvent:
-      type: object
       allOf:
         - $ref: "#/components/schemas/Event"
-      properties:
-        eventDetail:
-          type: object
-          description: Event details depending on the event type
-          required:
-            - sessionId
-            - qosStatus
+        - type: object
           properties:
-            sessionId:
-              $ref: "#/components/schemas/SessionId"
-            qosStatus:
-              $ref: "#/components/schemas/EventQosStatus"
-            statusInfo:
-              $ref: "#/components/schemas/StatusInfo"
-      required:
-        - eventDetail
+            eventDetail:
+              type: object
+              description: Event details depending on the event type
+              required:
+                - sessionId
+                - qosStatus
+              properties:
+                sessionId:
+                  $ref: "#/components/schemas/SessionId"
+                qosStatus:
+                  $ref: "#/components/schemas/EventQosStatus"
+                statusInfo:
+                  $ref: "#/components/schemas/StatusInfo"
+          required:
+            - eventDetail
 
     StatusInfo:
           description: |

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -113,7 +113,7 @@ paths:
                 content:
                   application/json:
                     schema:
-                      $ref: "#/components/schemas/Event"
+                      $ref: "#/components/schemas/EventNotification"
               responses:
                 "204":
                   description: Successful notification
@@ -732,6 +732,18 @@ components:
         - Gbps
         - Tbps
 
+    EventNotification:
+      type: object
+      required:
+        - event
+      properties:
+        event:
+          $ref: "#/components/schemas/Event"
+        subscriptionId:
+          type: string
+          description: 'The ID of explicit subscription or none in case of implicit subscription'
+          example: '7698d710-98b7-4695-a958-7b228f08128c'
+
     Event:
       description: The event being notified
       type: object
@@ -739,7 +751,7 @@ components:
         - eventType
         - eventTime
       properties:
-        eventid:
+        eventId:
           $ref: "#/components/schemas/EventId"
         eventType:
           $ref: "#/components/schemas/EventType"


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature


#### What this PR does / why we need it:
Fix ability to send QosStatusChangedEvent from client side (Telco) to the server side of /notifications (QoS API Consumer) for those who use strongly typed Languages.
As QosStatusChangedEvent extends Event we can now send it as payload



#### Which issue(s) this PR fixes:

Fixes #174

#### Special notes for reviewers:
~~BREAKING CHANGE: Remove EventNotification to embed Event as notification payload~~ (reverted, see [bbe5812](https://github.com/camaraproject/QualityOnDemand/pull/177/commits/bbe5812db50f1b6bd0fa3f6b58bade2213a1fd70))

This specification replaces multiple inheritance schemes with single inheritance. This way the generator will stop to generate anonymous XXXAllOf.java classes which are not useful at all.

```yaml
ClassA:
   allOf:
      - $ref: ClassB
      - type: object
            properties:
                 prop1:
 ```   
That says ClassA inherit from ClassB and anonymous inlined object containing property prop1 is replaced by:

```yaml
ClassA:
   type: object
   allOf:
      - $ref: ClassB
   properties:
      prop1:
 ```   
That means: ClassA extends ClassB and contains property prop1.

#### Changelog input

```
Add inheritance beetween Event and QosStatusChangedEvent
Simplify Notification payload model and align it with DeviceStatus proposal 

```

#### Additional documentation 
