### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @hdamker @shilpa-padgaonkar
+* @hdamker @eric-murray @RandyLevensalor


### PR DESCRIPTION
As discussed with sub project maintainers


#### What type of PR is this?

Add one of the following kinds:
* subproject management

#### What this PR does / why we need it:

@shilpa-padgaonkar steps back as code owner in QoD, @eric-murray and @RandyLevensalor as active maintainers of the sub project volunteered as code owners.

#### Which issue(s) this PR fixes:
