### PR TITLE
Move "description" out of "allOf" declaration

### DIFF
--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -451,12 +451,12 @@ components:
         applicationServer:
           $ref: "#/components/schemas/ApplicationServer"
         devicePorts:
+          description: The ports used locally by the device for flows to which the requested QoS profile should apply. If omitted, then the qosProfile will apply to all flows between the device and the specified application server address and ports
           allOf:
-            - description: The ports used locally by the device for flows to which the requested QoS profile should apply. If omitted, then the qosProfile will apply to all flows between the device and the specified application server address and ports
-            - $ref: "#/components/schemas/PortsSpec" 
+            - $ref: "#/components/schemas/PortsSpec"
         applicationServerPorts:
+          description: A list of single ports or port ranges on the application server
           allOf:
-            - description: A list of single ports or port ranges on the application server
             - $ref: "#/components/schemas/PortsSpec"
         qosProfile:
           $ref: "#/components/schemas/QosProfileName"
@@ -532,77 +532,77 @@ components:
         status:
           $ref: "#/components/schemas/QosProfileStatusEnum"
         targetMinUpstreamRate:
+          description: |
+            This is the target minimum upstream rate for the QoS profile.
+            
+            For 5G networks 3GPP Guaranteed Bit Rate (GBR) refers to a dedicated, fixed data rate assigned to
+            specific services, ensuring a minimum performance level. As per 3GPP TS 23.203,
+            GBR is a QoS parameter used to manage traffic classes in mobile networks. It
+            provides a stable data rate for latency-sensitive applications, such as voice calls or
+            video streaming, helping maintain a consistent user experience. When this attribute is set
+            this could imply that a GBR QCI is used, though mechanisms on the network can be used to
+            ensure a minimum performance level without using a GBR QCI.
+            
+            The committed data rate allocated to specific services, ensuring a consistent level of
+            performance. For DOCSIS networks, the "Minimum Reserved Traffic Rate" is defined in the 
+            DOCSIS 3.1 - MAC and Upper Layer Protocols Interface Specification" 
+            and it ensures a consistent level of performance for specific services within the network.
           allOf:
             - $ref: "#/components/schemas/Rate"
-            - description: |
-                This is the target minimum upstream rate for the QoS profile.
-
-                For 5G networks 3GPP Guaranteed Bit Rate (GBR) refers to a dedicated, fixed data rate assigned to
-                specific services, ensuring a minimum performance level. As per 3GPP TS 23.203,
-                GBR is a QoS parameter used to manage traffic classes in mobile networks. It
-                provides a stable data rate for latency-sensitive applications, such as voice calls or
-                video streaming, helping maintain a consistent user experience. When this attribute is set
-                this could imply that a GBR QCI is used, though mechanisms on the network can be used to
-                ensure a minimum performance level without using a GBR QCI.
-
-                The committed data rate allocated to specific services, ensuring a consistent level of
-                performance. For DOCSIS networks, the "Minimum Reserved Traffic Rate" is defined in the 
-                DOCSIS 3.1 - MAC and Upper Layer Protocols Interface Specification" 
-                and it ensures a consistent level of performance for specific services within the network.
         maxUpstreamRate:
+          description: |
+            The maximum best effort data
           allOf:
             - $ref: "#/components/schemas/Rate"
-            - description: |
-                The maximum best effort data
         maxUpstreamBurstRate:
+          description: |
+            When defined, this is the maximum upstream burst rate for the QoS profile, that will enable
+            the network to burst data at a higher rate than the maxUpstreamRate for a period of time.
           allOf:
             - $ref: "#/components/schemas/Rate"
-            - description: |
-                When defined, this is the maximum upstream burst rate for the QoS profile, that will enable
-                the network to burst data at a higher rate than the maxUpstreamRate for a period of time.
         targetMinDownstreamRate:
+          description: |
+            This is the target minimum downstream rate for the QoS profile.
+            
+            For 5G networks 3GPP Guaranteed Bit Rate (GBR) refers to a dedicated, fixed data rate assigned to
+            specific services, ensuring a minimum performance level. As per 3GPP TS 23.203,
+            GBR is a QoS parameter used to manage traffic classes in mobile networks. It
+            provides a stable data rate for latency-sensitive applications, such as voice calls or
+            video streaming, helping maintain a consistent user experience.  When this attribute is set
+            this could imply that a GBR QCI is used, though mechanisms on the network can be used to
+            ensure a minimum performance level without using a GBR QCI.
+            
+            The committed data rate allocated to specific services, ensuring a consistent level of
+            performance. DOCSIS networks, the "Minimum Reserved Traffic Rate" is defined in the 
+            DOCSIS 3.1 - MAC and Upper Layer Protocols Interface Specification" 
+            and it ensures a consistent level of performance for specific services within the network.
           allOf:
             - $ref: "#/components/schemas/Rate"
-            - description: |
-                This is the target minimum downstream rate for the QoS profile.
-
-                For 5G networks 3GPP Guaranteed Bit Rate (GBR) refers to a dedicated, fixed data rate assigned to
-                specific services, ensuring a minimum performance level. As per 3GPP TS 23.203,
-                GBR is a QoS parameter used to manage traffic classes in mobile networks. It
-                provides a stable data rate for latency-sensitive applications, such as voice calls or
-                video streaming, helping maintain a consistent user experience.  When this attribute is set
-                this could imply that a GBR QCI is used, though mechanisms on the network can be used to
-                ensure a minimum performance level without using a GBR QCI.
-
-                The committed data rate allocated to specific services, ensuring a consistent level of
-                performance. DOCSIS networks, the "Minimum Reserved Traffic Rate" is defined in the 
-                DOCSIS 3.1 - MAC and Upper Layer Protocols Interface Specification" 
-                and it ensures a consistent level of performance for specific services within the network.
         maxDownstreamRate:
+          description: |
+            The maximum best effort rate
           allOf:
             - $ref: "#/components/schemas/Rate"
-            - description: |
-                The maximum best effort rate
         maxDownstreamBurstRate:
+          description: |
+            When defined, this is the maximum downstream burst rate for the QoS profile, that will enable
+            the network to burst data at a higher rate than the maxDownstreamRate for a period of time.
+            
+            This can result in improved user experience when there is additional network capacity.
+            For instance, when a user is streaming a video, the network can burst data at a higher rate
+            to fill the buffer, and then return to the maxUpstreamRate once the buffer is full.
           allOf:
             - $ref: "#/components/schemas/Rate"
-            - description: |
-                When defined, this is the maximum downstream burst rate for the QoS profile, that will enable
-                the network to burst data at a higher rate than the maxDownstreamRate for a period of time.
-
-                This can result in improved user experience when there is additional network capacity.
-                For instance, when a user is streaming a video, the network can burst data at a higher rate
-                to fill the buffer, and then return to the maxUpstreamRate once the buffer is full.
         minDuration:
+          description: |
+            The shortest time period that this profile can be deployed.
           allOf:
             - $ref: "#/components/schemas/Duration"
-            - description: |
-                The shortest time period that this profile can be deployed.
         maxDuration:
+          description: |
+            The maximum time period that this profile can be deployed.
           allOf:
             - $ref: "#/components/schemas/Duration"
-            - description: |
-                The maximum time period that this profile can be deployed.
         priority:
           type: integer
           example: 20
@@ -617,26 +617,26 @@ components:
           minimum: 1
           maximum: 100
         packetDelayBudget:
+          description: |
+            The packet delay budget is the maximum allowable one-way latency between the customer's device
+            and the gateway from the operator's network to other networks. By limiting the delay, the network
+            can provide an acceptable level of performance for various services, such as voice calls,
+            video streaming, and data.
+            
+            The end-to-end or round trip latency will be about two times this value plus the latency not controlled
+            by the operator
           allOf:
             - $ref: "#/components/schemas/Duration"
-            - description: |
-                The packet delay budget is the maximum allowable one-way latency between the customer's device
-                and the gateway from the operator's network to other networks. By limiting the delay, the network
-                can provide an acceptable level of performance for various services, such as voice calls,
-                video streaming, and data.
-
-                The end-to-end or round trip latency will be about two times this value plus the latency not controlled
-                by the operator
         jitter:
+          description: |
+            The jitter requirement aims to limit the maximum variation in round-trip
+            packet delay for the 99th percentile of traffic, following ITU Y.1540
+            standards. It considers only acknowledged packets in a session, which are
+            packets that receive a confirmation of receipt from the recipient (e.g.,
+            using TCP). This requirement helps maintain consistent latency, essential
+            for real-time applications such as VoIP, video calls, and gaming.
           allOf:
             - $ref: "#/components/schemas/Duration"
-            - description: |
-                The jitter requirement aims to limit the maximum variation in round-trip
-                packet delay for the 99th percentile of traffic, following ITU Y.1540
-                standards. It considers only acknowledged packets in a session, which are
-                packets that receive a confirmation of receipt from the recipient (e.g.,
-                using TCP). This requirement helps maintain consistent latency, essential
-                for real-time applications such as VoIP, video calls, and gaming.
         packetErrorLossRate:
           type: integer
           description: |


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:
We are currently discovering that by using an openapi generator the current version 0.9.0 of QoD causes problems by having the "description" inside of "allOf"-declaration



#### Which issue(s) this PR fixes:



Fixes #204