### PR TITLE
Update of CHANGELOG and README with user friendly doc links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ Version numbers 0.2.x to 0.7.x were intentionally not used to avoid conflicts wi
 
 **This is the third alpha version of the Quality-On-Demand (QoD) API.**
 
-- [API definition with inline documentation](https://github.com/camaraproject/QualityOnDemand/tree/release-0.9.0/code/API_definitions)
+- API definition **with inline documentation**:
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/QualityOnDemand/blob/release-0.9.0/code/API_definitions/qod-api.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.9.0/code/API_definitions/qod-api.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.9.0/code/API_definitions/qod-api.yaml)
 
 ## Please note:
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Repository to describe, develop, document and test the QualityOnDemand API famil
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
 * **The latest available release and version of Quality-On-Demand (QoD) API is 0.9.0. This is the third alpha version of the API.** There are bug fixes to be expected and incompatible changes in upcoming releases. It is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
 * Release 0.9.0 of the API is available within the [release-0.9.0 branch](https://github.com/camaraproject/QualityOnDemand/tree/release-0.9.0):
-  * [API definition with inline documentation](https://github.com/camaraproject/QualityOnDemand/tree/release-0.9.0/code/API_definitions)
-  * For changes see [CHANGELOG.md](https://github.com/camaraproject/QualityOnDemand/blob/main/CHANGELOG.md)
+  - API definition **with inline documentation**:
+    - OpenAPI [YAML spec file](https://github.com/camaraproject/QualityOnDemand/blob/release-0.9.0/code/API_definitions/qod-api.yaml)
+    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.9.0/code/API_definitions/qod-api.yaml&nocors)
+    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.9.0/code/API_definitions/qod-api.yaml)
 * The previous version v0.8.1 of the QoD API is available within the [release-0.8.1 branch](https://github.com/camaraproject/QualityOnDemand/tree/release-0.8.1)
 * Provider implementations (PI) will be provided within separate repositories:
   * [QualityOnDemand_PI1](https://github.com/camaraproject/QualityOnDemand_PI1) by Deutsche Telekom


### PR DESCRIPTION
#### What type of PR is this?

documentation
subproject management

#### What this PR does / why we need it:

Update README and CHANGELOG, adding Redoc and Swagger links for v0.9.0 which allow to view the API definition and documentation in a more visual and friendly way.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #199 

#### Special notes for reviewers:

Same change as in CHANGELOG will be applied (manually) to the v0.9.0 release definition in Github as soon as the PR is merged.
