### PR TITLE
add 400 - Bad Request for invalid session ID in GET & DELETE /sessions/{sessionId}

### DIFF
--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -277,6 +277,8 @@ paths:
       responses:
         "204":
           description: Session deleted
+        "400":
+          $ref: "#/components/responses/Generic400"
         "401":
           $ref: "#/components/responses/Generic401"
         "403":

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -244,6 +244,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SessionInfo"
+        "400":
+          $ref: "#/components/responses/Generic400"
         "401":
           $ref: "#/components/responses/Generic401"
         "403":


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* enhancement 

#### What this PR does / why we need it:
There is no expected behaviour for an malformed Session-Id in the GET- & DELETE-request.
This PR shell add a Bad Request (HTTP 400) for the GET & DELETE /sessions/{sessionId} - endpoint.

#### Which issue(s) this PR fixes:

Fixes #209 
