### PR TITLE
fix: disable yamllint truthy-rule

### DIFF
--- a/.github/workflows/swagger-editor-validator.yml
+++ b/.github/workflows/swagger-editor-validator.yml
@@ -1,5 +1,5 @@
 ---
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - main


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug

#### What this PR does / why we need it:
This PR also fix the megalinter issue to disable "on"-keyword validation (truthy)



#### Which issue(s) this PR fixes:


Fixes #211

