### PR TITLE
issue_194_PR

### DIFF
--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -433,12 +433,7 @@ components:
       description: Attributes required to create a session
       type: object
       properties:
-        applicationConsumerId:
-          description: |
-            Identifies the application consumer that initiates a qos session. The ID is systematically relayed to downstream systems, including but not limited to, the Network Exposure Function (NEF) and the Policy Control Function (PCF) within the 5G framework.
-            The primary utility of this transmission is to facilitate the application of relevant policies, ensuring that the application consumer is appropriately tagged within usage records.
-          type: string
-          example: XRapp123
+
         duration:
           description: |
             Session duration in seconds. Maximal value of 24 hours is used if not set.
@@ -872,6 +867,12 @@ components:
         * `ipv6Address` 
       type: object
       properties:
+        applicationId:
+          description: |
+            A public identifier that uniquely identifies the application initiating a QoS session. The applicationId is more granular than the clientId, which identifies the unique customer. A client or customer could have one or more applications that need to be tracked. The Id is systematically relayed to downstream systems, including but not limited to, the Network Exposure Function (NEF) and the Policy Control Function (PCF) within the 5G framework.
+            The primary utility of this transmission is to facilitate the application of relevant policies, ensuring that the application is appropriately tagged within usage records.
+          type: string
+          example: XRapp123
         ipv4Address:
           $ref: "#/components/schemas/Ipv4Address"
         ipv6Address:

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -433,7 +433,6 @@ components:
       description: Attributes required to create a session
       type: object
       properties:
-
         duration:
           description: |
             Session duration in seconds. Maximal value of 24 hours is used if not set.

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -858,12 +858,14 @@ components:
 
     ApplicationServer:
       description: |
-        A server hosting backend applications to deliver some business logic to clients.
+        A server hosting backend applications to deliver a service to the identified `device`.
         
-        The developer can choose to provide the below specified device identifiers:
-
+        The developer must provide at least one of the following device identifiers:
         * `ipv4Address`
-        * `ipv6Address` 
+        * `ipv6Address`
+
+        In addition, the developer can specify an `applicationId` for policy control / audit purposes. The `applicationId` is not sufficient in itself to identity the application server.
+        
       type: object
       properties:
         applicationId:

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -433,6 +433,12 @@ components:
       description: Attributes required to create a session
       type: object
       properties:
+        applicationConsumerId:
+          description: |
+            Identifies the application consumer that initiates a qos session. The ID is systematically relayed to downstream systems, including but not limited to, the Network Exposure Function (NEF) and the Policy Control Function (PCF) within the 5G framework.
+            The primary utility of this transmission is to facilitate the application of relevant policies, ensuring that the application consumer is appropriately tagged within usage records.
+          type: string
+          example: XRapp123
         duration:
           description: |
             Session duration in seconds. Maximal value of 24 hours is used if not set.

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -859,13 +859,12 @@ components:
     ApplicationServer:
       description: |
         A server hosting backend applications to deliver a service to the identified `device`.
-        
+
         The developer must provide at least one of the following device identifiers:
         * `ipv4Address`
         * `ipv6Address`
 
         In addition, the developer can specify an `applicationId` for policy control / audit purposes. The `applicationId` is not sufficient in itself to identity the application server.
-        
       type: object
       properties:
         applicationId:


### PR DESCRIPTION
#### What type of PR is this?
* PR for introducing application consumer Id as discussed in #194 
Add one of the following kinds:

* enhancement/feature



#### What this PR does / why we need it:

* Identifies the application consumer that initiates a qos session. The ID is systematically relayed to downstream systems, including but not limited to, the Network Exposure Function (NEF) and the Policy Control Function (PCF) within the 5G framework. The primary utility of this transmission is to facilitate the application of relevant policies, ensuring that the application consumer is appropriately tagged within usage records.
     


#### Which issue(s) this PR fixes:


<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #194 

#### Special notes for reviewers:

For lack of the better term i am proposing "applicationConsumerId" as string type field. Open for suggestions


#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
