### PR TITLE
Creation of release candicate v0.10.0-rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ Version numbers 0.2.x to 0.7.x were intentionally not used to avoid conflicts wi
 ## Please note:
 
 - **This release will contain significant changes compared to v0.9.0, and it is not backward compatible**
-  - Especially ...
+  - Within notifications the schema `EventNotification`has been replace by `CloudEvent` in accordance with the updated CAMARA Design Guidelines
+  - If within `device` an IPv6 address is used it must be a single IPv6 address (out of the prefix used by the device)
 - **This is only the pre-release, it should be considered as a draft of the upcoming release v0.10.0**
   - The pre-release is meant for implementors, but it is not recommended to use the API with customers in productive environments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,18 +37,16 @@ Version numbers 0.2.x to 0.7.x were intentionally not used to avoid conflicts wi
 
 ### Added
 
-* TBD - #216 Added operation to extend session duration
+* Added new endpoint to extend duration of an active session by @emil-cheung in https://github.com/camaraproject/QualityOnDemand/pull/216
 * Introduced of linting with Megalinter and Swagger Editor Validator by @RandyLevensalor, @maxl2287 and @ravindrapalaskar17 in https://github.com/camaraproject/QualityOnDemand/pull/206, https://github.com/camaraproject/QualityOnDemand/pull/207, https://github.com/camaraproject/QualityOnDemand/pull/212, and  https://github.com/camaraproject/QualityOnDemand/pull/215
 * Added global tags element  by @rartych in https://github.com/camaraproject/QualityOnDemand/pull/227
 
-
 ### Changed
 
-* TBD - #224 Aligned event notification with CloudEvent spec
+* Align event notification with CloudEvents spec by @jlurien in https://github.com/camaraproject/QualityOnDemand/pull/224
 * Moved "description" out of "allOf" declaration by @maxl2287 in https://github.com/camaraproject/QualityOnDemand/pull/205
   * Note: this change shouldn't have an impact for API consumers but is relevant for implementations of the API.
-* TDB - #233 Default folder for test definition created and QoD_API_Test.feature copied into it 
-
+* Aligned with changes in https://github.com/camaraproject/Template_Lead_Repository on test definitions by @rartych in https://github.com/camaraproject/QualityOnDemand/pull/233
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [v0.10.0-rc](#v0100-rc)
 - [v0.9.0](#v090)
 - [v0.9.0-rc](#v090-rc)
 - [v0.8.1](#v081)
@@ -11,6 +12,58 @@
 Version numbers 0.2.x to 0.7.x were intentionally not used to avoid conflicts with local implementations.
 
 **Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
+
+# v0.10.0-rc
+
+**This is the release candidate of v0.10.0 - containing the upcoming fourth alpha version of the Quality-On-Demand (QoD) API**
+
+- API definition **with inline documentation**:
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/QualityOnDemand/blob/release-0.10.0-rc/code/API_definitions/qod-api.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.10.0-rc/code/API_definitions/qod-api.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.10.0-rc/code/API_definitions/qod-api.yaml)
+
+## Please note:
+
+- **This release will contain significant changes compared to v0.9.0, and it is not backward compatible**
+  - Especially ...
+- **This is only the pre-release, it should be considered as a draft of the upcoming release v0.10.0**
+  - The pre-release is meant for implementors, but it is not recommended to use the API with customers in productive environments.
+
+### Main Changes
+
+* Aligned event notification with CloudEvent spec which will allow API consumers and implementators to use standard libraries and tools which are available to handle cloud events
+* Added a new operation `/sessions/{sessionId}/extend` which allows to extend the duration of an active session 
+
+
+### Added
+
+* TBD - #216 Added operation to extend session duration
+* Introduced of linting with Megalinter and Swagger Editor Validator by @RandyLevensalor, @maxl2287 and @ravindrapalaskar17 in https://github.com/camaraproject/QualityOnDemand/pull/206, https://github.com/camaraproject/QualityOnDemand/pull/207, https://github.com/camaraproject/QualityOnDemand/pull/212, and  https://github.com/camaraproject/QualityOnDemand/pull/215
+* Added global tags element  by @rartych in https://github.com/camaraproject/QualityOnDemand/pull/227
+
+
+### Changed
+
+* TBD - #224 Aligned event notification with CloudEvent spec
+* Moved "description" out of "allOf" declaration by @maxl2287 in https://github.com/camaraproject/QualityOnDemand/pull/205
+  * Note: this change shouldn't have an impact for API consumers but is relevant for implementations of the API.
+* TDB - #233 Default folder for test definition created and QoD_API_Test.feature copied into it 
+
+
+### Fixed
+
+* NA
+  
+### Removed
+
+* NA
+
+## New Contributors
+* @ravindrapalaskar17 made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/215
+* @rartych made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/227
+
+**Full Changelog**: https://github.com/camaraproject/QualityOnDemand/compare/v0.9.0...v0.10.0-rc
+
 
 # v0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Version numbers 0.2.x to 0.7.x were intentionally not used to avoid conflicts wi
 
 ### Main Changes
 
-* Aligned event notification with CloudEvent spec which will allow API consumers and implementators to use standard libraries and tools which are available to handle cloud events
+* Aligned event notification with CloudEvent spec which will allow API consumers and implementators to use standard libraries and tools which are available to handle CloudEvents (https://cloudevents.io/)
 * Added a new operation `/sessions/{sessionId}/extend` which allows to extend the duration of an active session 
 
 
@@ -47,6 +47,7 @@ Version numbers 0.2.x to 0.7.x were intentionally not used to avoid conflicts wi
 * Moved "description" out of "allOf" declaration by @maxl2287 in https://github.com/camaraproject/QualityOnDemand/pull/205
   * Note: this change shouldn't have an impact for API consumers but is relevant for implementations of the API.
 * Aligned with changes in https://github.com/camaraproject/Template_Lead_Repository on test definitions by @rartych in https://github.com/camaraproject/QualityOnDemand/pull/233
+* Single IP addresses in Device model specified with standard formats instead of patterns by @jlurien in https://github.com/camaraproject/QualityOnDemand/pull/237
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,24 @@ Repository to describe, develop, document and test the QualityOnDemand API famil
 
 ## Status and released versions
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
-* **The latest available release and version of Quality-On-Demand (QoD) API is 0.9.0. This is the third alpha version of the API.** There are bug fixes to be expected and incompatible changes in upcoming releases. It is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
-* Release 0.9.0 of the API is available within the [release-0.9.0 branch](https://github.com/camaraproject/QualityOnDemand/tree/release-0.9.0):
-  - API definition **with inline documentation**:
+
+* **The Release Candidate for v0.10.0 of the Quality-On-Demand is available. The upcoming release will contain the fourth alpha version of the QoD API**<br>Until the release there are bug fixes to be expected. The release candidate is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
+* The release candidate for v0.10.0 is available in the [release-0.10.0-rc branch](https://github.com/camaraproject/QualityOnDemand/tree/release-0.10.0-rc)
+  - API definition with inline documentation:
+    - OpenAPI [YAML spec file](https://github.com/camaraproject/QualityOnDemand/blob/release-0.10.0-rc/code/API_definitions/qod-api.yaml)
+    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.10.0-rc/code/API_definitions/qod-api.yaml&nocors)
+    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.10.0-rc/code/API_definitions/qod-api.yaml)
+  - For changes between v0.10.0-rc and v0.9.0 see the [CHANGELOG.md](https://github.com/camaraproject/QualityOnDemand/blob/main/CHANGELOG.md)
+
+
+* The latest available and released version 0.9.0 of the API is available within the [release-0.9.0 branch](https://github.com/camaraproject/QualityOnDemand/tree/release-0.9.0)
+  - API definition with inline documentation:
     - OpenAPI [YAML spec file](https://github.com/camaraproject/QualityOnDemand/blob/release-0.9.0/code/API_definitions/qod-api.yaml)
     - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.9.0/code/API_definitions/qod-api.yaml&nocors)
-    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.9.0/code/API_definitions/qod-api.yaml)
-* The previous version v0.8.1 of the QoD API is available within the [release-0.8.1 branch](https://github.com/camaraproject/QualityOnDemand/tree/release-0.8.1)
-* Provider implementations (PI) will be provided within separate repositories:
+    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.9.0/code/API_definitions/qod-api.yaml) 
+
+
+* Provider implementations (PI) are available within separate repositories:
   * [QualityOnDemand_PI1](https://github.com/camaraproject/QualityOnDemand_PI1) by Deutsche Telekom
   * [QualityOnDemand_PI2](https://github.com/camaraproject/QualityOnDemand_PI2) by Orange
   * [QualityOnDemand_PI3](https://github.com/camaraproject/QualityOnDemand_PI3) by Spry Fox Networks

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -66,7 +66,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.10.0-wip
+  version: 0.10.0-rc
 externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* documentation
* subproject management

#### What this PR does / why we need it:

The merge of this PR will be the target commit for the first release candidate of v0.10.0, getting the tag `v0.10.0-rc`

#### Which issue(s) this PR fixes:

Fixes #235 

#### Special notes for reviewers:

Currently draft PR, as the final information about the PRs included in the release candidate are not yet available.

#### Changelog input

NA

#### Additional documentation 

