### PR TITLE
Added a note to maxDuration parameter within qosProfile about the limit of 86400 seconds

### DIFF
--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -687,6 +687,8 @@ components:
         maxDuration:
           description: |
             The maximum time period that this profile can be deployed.
+            NOTE: currently the duration within `sessionInfo` is limited to 86400 seconds (1 day).
+            The value of `maxDuration` shouldn't therefore exceed this time period. The limitation might be removed in later versions.
           allOf:
             - $ref: "#/components/schemas/Duration"
         priority:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation

#### What this PR does / why we need it:

Add a note to maxDuration parameter that the value shouldn't exceed the current limitation within sessionInfo of 86400 seconds


#### Which issue(s) this PR fixes:

This is a temporary measure for #249 but won't fix it. See comment within the issue.

#### Special notes for reviewers:



#### Changelog input

```
Added a note to maxDuration parameter within qosProfile about the limit of 86400 seconds

```
