### PR TITLE
Added clarification of notifications to be sent and added StatusInfo "DELETE_REQUESTED" to addres #241

### DIFF
--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -105,10 +105,10 @@ paths:
         A `QOS_STATUS_CHANGED` event notification with `qosStatus` as `UNAVAILABLE` will also be send if the network terminates the session before the requested duration expired
 
         NOTE: in case of a `QOS_STATUS_CHANGED` event with `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED` the resources of the QoS session
-        are not directly set free, but will get deleted automatically only 360 seconds after the event.
+        are not directly released, but will get deleted automatically only 360 seconds after the event.
         This behavior should allow clients which are not receiving notification events but are polling the session information the opportunity
         to see the `qosStatus` `UNAVAILABLE` and `statusInfo` `NETWORK_TERMINATED`. Before a client can attempt to create a new QoD session
-        for the same device and flow within this time period they must free the session resources with an explicit `delete` operation.
+        for the same device and flow within this time period they must release the session resources with an explicit `delete` operation.
 
       operationId: createSession
       requestBody:
@@ -291,7 +291,7 @@ paths:
         - QoS Sessions
       summary: Delete a QoS session
       description: |
-        Free resources related to QoS session
+        Release resources related to QoS session
 
         If the notification callback is provided and the `qosStatus` of the session was `AVAILABLE` the client will receive in addition to the response a `QOS_STATUS_CHANGED` event with
         - `qosStatus` as `UNAVAILABLE` and
@@ -1060,8 +1060,8 @@ components:
     EventQosStatus:
       description: |
         The current status of a requested or previously available session. Applicable values in the event are:
-        *  `AVAILABLE` - The requested QoS has been provided by the network. NOTE: this event will be sent always, also if status within the response to `createSession` is already `AVAILABLE`
-        *  `UNAVAILABLE` - A requested or previously available QoS session is currently unavailable. `statusInfo` may provide additional information about the reason for the unavailability. NOTE: this event will be sent always, also if the user deletes the session explicitly
+        *  `AVAILABLE` - The requested QoS has been provided by the network.
+        *  `UNAVAILABLE` - A requested or previously available QoS session is now unavailable. `statusInfo` may provide additional information about the reason for the unavailability.
       type: string
       enum:
         - AVAILABLE

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -95,11 +95,21 @@ paths:
       description: |
         Create QoS Session to manage latency/throughput priorities
 
-        If the notification callback is provided the client will receive in addition to the response a `QOS_STATUS_CHANGED` event with either
-        - `qosStatus` as `AVAILABLE` when the session has been provided by the network, or
-        - `qosStatus` as `UNAVAILABLE` if the requested session is currently not available.
+        If the qosStatus in the API response is "AVAILABLE" and a notification callback is provided the client will receive in addition to the response a
+        `QOS_STATUS_CHANGED` event notification with `qosStatus` as `AVAILABLE`.
 
-        If the `qosStatus` in the API response is `REQUESTED`, the notification will be sent either after the network notifies that it has created the requested session or after the network notifies that it has failed to provide the requested session.
+        If the `qosStatus` in the API response is `REQUESTED`, the client will receive either
+        - a `QOS_STATUS_CHANGED` event notification with `qosStatus` as `AVAILABLE` after the network notifies that it has created the requested session, or
+        - a `QOS_STATUS_CHANGED` event notification with `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED` after the network notifies that it has failed to provide the requested session.
+
+        A `QOS_STATUS_CHANGED` event notification with `qosStatus` as `UNAVAILABLE` will also be send if the network terminates the session before the requested duration expired
+
+        NOTE: in case of a `QOS_STATUS_CHANGED` event with `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED` the resources of the QoS session 
+        are not directly set free, but will get deleted automatically only 360 seconds after the event.
+        This behavior should allow clients which are not receiving notification events but are polling the session information the opportunity 
+        to see the `qosStatus` `UNAVAILABLE` and `statusInfo` `NETWORK_TERMINATED`. Before a client can attempt to create a new QoD session 
+        for the same device and flow within this time period they must free the session resources with an explicit `delete` operation.
+
       operationId: createSession
       requestBody:
         description: Parameters to create a new session
@@ -283,9 +293,10 @@ paths:
       description: |
         Free resources related to QoS session
 
-        If the notification callback is provided the client will receive in addition to the response a `QOS_STATUS_CHANGED` event with
+        If the notification callback is provided and the `qosStatus` of the session was `AVAILABLE` the client will receive in addition to the response a `QOS_STATUS_CHANGED` event with
         - `qosStatus` as `UNAVAILABLE` and
         - `statusInfo` as `DELETE_REQUESTED`
+        There will be no event notification if the `qosStatus` was already `UNAVAILABLE`.
       operationId: deleteSession
       parameters:
         - name: sessionId
@@ -900,6 +911,7 @@ components:
         * `DURATION_EXPIRED` - Session terminated due to requested duration expired
         * `NETWORK_TERMINATED` - Network terminated the session before the requested duration expired
         * `DELETE_REQUESTED`- User requested the deletion of the session before the requested duration expired
+
       type: string
       enum:
         - DURATION_EXPIRED

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -285,7 +285,7 @@ paths:
 
         If the notification callback is provided the client will receive in addition to the response a `QOS_STATUS_CHANGED` event with
         - `qosStatus` as `UNAVAILABLE` and
-        - `statusInfo` as `USER_DELETED`
+        - `statusInfo` as `DELETE_REQUESTED`
       operationId: deleteSession
       parameters:
         - name: sessionId

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -105,10 +105,10 @@ paths:
         A `QOS_STATUS_CHANGED` event notification with `qosStatus` as `UNAVAILABLE` will also be send if the network terminates the session before the requested duration expired
 
         NOTE: in case of a `QOS_STATUS_CHANGED` event with `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED` the resources of the QoS session
-        are not directly released, but will get deleted automatically only 360 seconds after the event.
-        This behavior should allow clients which are not receiving notification events but are polling the session information the opportunity
-        to see the `qosStatus` `UNAVAILABLE` and `statusInfo` `NETWORK_TERMINATED`. Before a client can attempt to create a new QoD session
-        for the same device and flow within this time period they must release the session resources with an explicit `delete` operation.
+        are not directly released, but will get deleted automatically at earliest 360 seconds after the event.
+        This behavior allows clients which are not receiving notification events but are polling to get the session information with
+        the `qosStatus` `UNAVAILABLE` and `statusInfo` `NETWORK_TERMINATED`. Before a client can attempt to create a new QoD session
+        for the same device and flow period they must release the session resources with an explicit `delete` operation if not yet automatically deleted.
 
       operationId: createSession
       requestBody:

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -104,10 +104,10 @@ paths:
 
         A `QOS_STATUS_CHANGED` event notification with `qosStatus` as `UNAVAILABLE` will also be send if the network terminates the session before the requested duration expired
 
-        NOTE: in case of a `QOS_STATUS_CHANGED` event with `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED` the resources of the QoS session 
+        NOTE: in case of a `QOS_STATUS_CHANGED` event with `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED` the resources of the QoS session
         are not directly set free, but will get deleted automatically only 360 seconds after the event.
-        This behavior should allow clients which are not receiving notification events but are polling the session information the opportunity 
-        to see the `qosStatus` `UNAVAILABLE` and `statusInfo` `NETWORK_TERMINATED`. Before a client can attempt to create a new QoD session 
+        This behavior should allow clients which are not receiving notification events but are polling the session information the opportunity
+        to see the `qosStatus` `UNAVAILABLE` and `statusInfo` `NETWORK_TERMINATED`. Before a client can attempt to create a new QoD session
         for the same device and flow within this time period they must free the session resources with an explicit `delete` operation.
 
       operationId: createSession
@@ -296,7 +296,7 @@ paths:
         If the notification callback is provided and the `qosStatus` of the session was `AVAILABLE` the client will receive in addition to the response a `QOS_STATUS_CHANGED` event with
         - `qosStatus` as `UNAVAILABLE` and
         - `statusInfo` as `DELETE_REQUESTED`
-        There will be no event notification if the `qosStatus` was already `UNAVAILABLE`.
+        There will be no notification event if the `qosStatus` was already `UNAVAILABLE`.
       operationId: deleteSession
       parameters:
         - name: sessionId

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -99,7 +99,7 @@ paths:
         - `qosStatus` as `AVAILABLE` when the session has been provided by the network, or
         - `qosStatus` as `UNAVAILABLE` if the requested session is currently not available.
 
-        In case that the  `qosStatus` in the response is `REQUESTED` the notification will be send after the session has been provided by the network or couldn't be provided
+        If the `qosStatus` in the API response is `REQUESTED`, the notification will be sent either after the network notifies that it has created the requested session or after the network notifies that it has failed to provide the requested session.
       operationId: createSession
       requestBody:
         description: Parameters to create a new session
@@ -899,12 +899,12 @@ components:
         Reason for the new `qosStatus`. Currently `statusInfo` is only applicable when `qosStatus` is 'UNAVAILABLE'.
         * `DURATION_EXPIRED` - Session terminated due to requested duration expired
         * `NETWORK_TERMINATED` - Network terminated the session before the requested duration expired
-        * `USER_DELETED`- User deleted the session before the requested duration expired
+        * `DELETE_REQUESTED`- User requested the deletion of the session before the requested duration expired
       type: string
       enum:
         - DURATION_EXPIRED
         - NETWORK_TERMINATED
-        - USER_DELETED
+        - DELETE_REQUESTED
 
     Device:
       description: |
@@ -1048,8 +1048,8 @@ components:
     EventQosStatus:
       description: |
         The current status of a requested or previously available session. Applicable values in the event are:
-        *  `AVAILABLE` - The requested QoS has been provided by the network. NOTE: this event will be send always, also if status within the response to `createSession` is already `AVAILABLE`
-        *  `UNAVAILABLE` - A requested or previously available QoS session is currently unavailable. `statusInfo` may provide additional information about the reason for the unavailability. NOTE: this event will be send always, also if the user deletes the session explicitly
+        *  `AVAILABLE` - The requested QoS has been provided by the network. NOTE: this event will be sent always, also if status within the response to `createSession` is already `AVAILABLE`
+        *  `UNAVAILABLE` - A requested or previously available QoS session is currently unavailable. `statusInfo` may provide additional information about the reason for the unavailability. NOTE: this event will be sent always, also if the user deletes the session explicitly
       type: string
       enum:
         - AVAILABLE

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -38,7 +38,7 @@ info:
     Duration (in seconds) for which the QoS session (between application client and application server) should be created. This parameter is optional. When not specified, a default session duration (e.g. 24 hours) is applied. The user may request a termination before its expiration.
 
     * **Notification URL and token**:
-    Developers may provide a callback URL on which notifications (eg. session termination) regarding the session can be received from the service provider. This is an optional parameter.
+    Developers may provide a callback URL on which notifications about all status change events of the session (eg. session termination) can be received from the service provider. This is an optional parameter.
 
     # API functionality
 
@@ -92,7 +92,14 @@ paths:
       tags:
         - QoS Sessions
       summary: Creates a new session
-      description: Create QoS Session to manage latency/throughput priorities
+      description: |
+        Create QoS Session to manage latency/throughput priorities
+
+        If the notification callback is provided the client will receive in addition to the response a `QOS_STATUS_CHANGED` event with either
+        - `qosStatus` as `AVAILABLE` when the session has been provided by the network, or
+        - `qosStatus` as `UNAVAILABLE` if the requested session is currently not available.
+
+        In case that the  `qosStatus` in the response is `REQUESTED` the notification will be send after the session has been provided by the network or couldn't be provided
       operationId: createSession
       requestBody:
         description: Parameters to create a new session
@@ -110,7 +117,7 @@ paths:
               summary: "Session notifications callback"
               description: |
                 Important: this endpoint is to be implemented by the API consumer.
-                The QoD server will call this endpoint whenever any network related event occurs.
+                The QoD server will call this endpoint whenever any QoS session change (e.g. network termination) related event occurs.
                 Currently only QOS_STATUS_CHANGED event is defined.
               operationId: postNotification
               requestBody:
@@ -273,7 +280,12 @@ paths:
       tags:
         - QoS Sessions
       summary: Delete a QoS session
-      description: Free resources related to QoS session
+      description: |
+        Free resources related to QoS session
+
+        If the notification callback is provided the client will receive in addition to the response a `QOS_STATUS_CHANGED` event with
+        - `qosStatus` as `UNAVAILABLE` and
+        - `statusInfo` as `USER_DELETED`
       operationId: deleteSession
       parameters:
         - name: sessionId
@@ -887,10 +899,12 @@ components:
         Reason for the new `qosStatus`. Currently `statusInfo` is only applicable when `qosStatus` is 'UNAVAILABLE'.
         * `DURATION_EXPIRED` - Session terminated due to requested duration expired
         * `NETWORK_TERMINATED` - Network terminated the session before the requested duration expired
+        * `USER_DELETED`- User deleted the session before the requested duration expired
       type: string
       enum:
         - DURATION_EXPIRED
         - NETWORK_TERMINATED
+        - USER_DELETED
 
     Device:
       description: |
@@ -1034,8 +1048,8 @@ components:
     EventQosStatus:
       description: |
         The current status of a requested or previously available session. Applicable values in the event are:
-        *  `AVAILABLE` - The requested QoS has been provided by the network
-        *  `UNAVAILABLE` - A requested or previously available QoS session is currently unavailable. `statusInfo` may provide additional information about the reason for the unavailability.
+        *  `AVAILABLE` - The requested QoS has been provided by the network. NOTE: this event will be send always, also if status within the response to `createSession` is already `AVAILABLE`
+        *  `UNAVAILABLE` - A requested or previously available QoS session is currently unavailable. `statusInfo` may provide additional information about the reason for the unavailability. NOTE: this event will be send always, also if the user deletes the session explicitly
       type: string
       enum:
         - AVAILABLE


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation
* correction

#### What this PR does / why we need it:

Adding clarification that notification will be sent for all changes of qosStatus and what happens when qosStatus change from AVAILABLE to UNAVAILABLE


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #241 and #254

#### Special notes for reviewers:

As notification should be sent in all QosStatus changes, there was the need to add the StatusInfo "DELETE_REQUESTED". 

#### Changelog input

```
Clarified in documentation that notifications will be sent for all changes of QosStatus, even if initiated by the client.
Clarified in documentation that the QoS session resource what will happen when qosStatus changes from 'AVAILABLE' to 'UNAVAILABLE' due to 'NETWORK_TERMINATED'

```
