### PR TITLE
Second release candidate of v0.10.0

### DIFF
--- a/.openapirc.yml
+++ b/.openapirc.yml
@@ -23,4 +23,4 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: ^[0-9]+\.[0-9]+\.[0-9]+(?:-rc|-wip)?$
+        match: ^[0-9]+\.[0-9]+\.[0-9]+(?:-rc|-rc2|-wip)?$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [v0.10.0-rc2](#v0100-rc2)
 - [v0.10.0-rc](#v0100-rc)
 - [v0.9.0](#v090)
 - [v0.9.0-rc](#v090-rc)
@@ -13,14 +14,32 @@ Version numbers 0.2.x to 0.7.x were intentionally not used to avoid conflicts wi
 
 **Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
 
-# v0.10.0-rc
+# v0.10.0-rc2
 
-**This is the release candidate of v0.10.0 - containing the upcoming fourth alpha version of the Quality-On-Demand (QoD) API**
+**This is the second release candidate of v0.10.0 - containing the upcoming fourth alpha version of the Quality-On-Demand (QoD) API**
 
 - API definition **with inline documentation**:
-  - OpenAPI [YAML spec file](https://github.com/camaraproject/QualityOnDemand/blob/release-0.10.0-rc/code/API_definitions/qod-api.yaml)
-  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.10.0-rc/code/API_definitions/qod-api.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.10.0-rc/code/API_definitions/qod-api.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/v0.10.0-rc2/code/API_definitions/qod-api.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/v0.10.0-rc2/code/API_definitions/qod-api.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/QualityOnDemand/blob/v0.10.0-rc2/code/API_definitions/qod-api.yaml)
+
+## Changes compared to [v0.10.0-rc](#v0100-rc)
+
+* Added a new error example for DurationOutOfRangeForQoSProfile by @jlurien in https://github.com/camaraproject/QualityOnDemand/pull/259
+* Moved "basePath" /qod/v0 to "url"-property and introduced "apiroot" in definition of server  @maxl2287 in https://github.com/camaraproject/QualityOnDemand/pull/252
+* Added a note to maxDuration parameter within qosProfile schema about the limit of 86400 seconds by @hdamker in https://github.com/camaraproject/QualityOnDemand/pull/256
+* Added statusInfo 'DELETE_REQUESTED' for qosStatus 'UNAVAILABLE' and clarified notification events in documentation by @hdamker in https://github.com/camaraproject/QualityOnDemand/pull/258:
+  * notifications will be sent for all changes of QosStatus, even if initiated by the client.
+  * what will happen when qosStatus changes from 'AVAILABLE' to 'UNAVAILABLE' due to 'NETWORK_TERMINATED'
+
+# v0.10.0-rc
+
+**This is the first release candidate of v0.10.0 - containing the upcoming fourth alpha version of the Quality-On-Demand (QoD) API**
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/v0.10.0-rc/code/API_definitions/qod-api.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/v0.10.0-rc/code/API_definitions/qod-api.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/QualityOnDemand/blob/v0.10.0-rc/code/API_definitions/qod-api.yaml)
 
 ## Please note:
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ Repository to describe, develop, document and test the QualityOnDemand API famil
 ## Status and released versions
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
 
-* **The Release Candidate for v0.10.0 of the Quality-On-Demand API is available. This upcoming release will contain the fourth alpha version of the QoD API**<br>Until the release there are bug fixes to be expected. The release candidate is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
-* The release candidate for v0.10.0 is available in the [release-0.10.0-rc branch](https://github.com/camaraproject/QualityOnDemand/tree/release-0.10.0-rc)
-  - API definition v0.10.0-rc with inline documentation:
-    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.10.0-rc/code/API_definitions/qod-api.yaml&nocors)
-    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.10.0-rc/code/API_definitions/qod-api.yaml)
-    - OpenAPI [YAML spec file](https://github.com/camaraproject/QualityOnDemand/blob/release-0.10.0-rc/code/API_definitions/qod-api.yaml)
-  - For changes between v0.10.0-rc and v0.9.0 see the [CHANGELOG.md](https://github.com/camaraproject/QualityOnDemand/blob/main/CHANGELOG.md)
+* **The second Release Candidate for v0.10.0 of the Quality-On-Demand API is available.**
+<br>Until the release there are bug fixes to be expected. The release candidate is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
+* The second release candidate for v0.10.0 is available in the [release-0.10.0-rc2 tag](https://github.com/camaraproject/QualityOnDemand/blob/v0.10.0-rc2/)
+- API definition with inline documentation:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/v0.10.0-rc2/code/API_definitions/qod-api.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/v0.10.0-rc2/code/API_definitions/qod-api.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/QualityOnDemand/blob/v0.10.0-rc2/code/API_definitions/qod-api.yaml)
+* For changes between v0.10.0-rc2 and v0.9.0 see the [CHANGELOG.md](https://github.com/camaraproject/QualityOnDemand/blob/main/CHANGELOG.md)
 
 * The latest available and released version 0.9.0 is available within the [release-0.9.0 branch](https://github.com/camaraproject/QualityOnDemand/tree/release-0.9.0)
   - API definition v0.9.0 with inline documentation:

--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -66,7 +66,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.10.0-wip
+  version: 0.10.0-rc2
 externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation
* subproject management

#### What this PR does / why we need it:

Create the second release candidate of v0.10.0-rc2:
* Update CHANGELOG.md with changes since v0.10.0-rc
* Update README.md with links to v0.10.0-rc2

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #260 

#### Special notes for reviewers:

- This PR is meant to be merged after #258.
- The links within CHANGELOG.md and README.md are getting valid after the tag v0.10.0-rc2 is created (pointing to merge request of this PR).
- The new text within CHANGELOG.md will be copied into the description of the Github pre-release v0.10.0-rc2.
