### PR TITLE
Patch of documentation to address #267 (lack of `statusInfo` in `SessionInfo`)

### DIFF
--- a/code/API_definitions/qod-api.yaml
+++ b/code/API_definitions/qod-api.yaml
@@ -104,7 +104,7 @@ paths:
         NOTE: in case of a `QOS_STATUS_CHANGED` event with `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED` the resources of the QoS session
         are not directly released, but will get deleted automatically at earliest 360 seconds after the event.
         This behavior allows clients which are not receiving notification events but are polling to get the session information with
-        the `qosStatus` `UNAVAILABLE` (but currently not the `statusInfo`, the parameter is planned to be added in a later release within the session information). Before a client can attempt to create a new QoD session
+        the `qosStatus` `UNAVAILABLE` (the `statusInfo` parameter is not included in the current version but will be adding to `SessionInfo` in an upcoming release). Before a client can attempt to create a new QoD session
         for the same device and flow period they must release the session resources with an explicit `delete` operation if not yet automatically deleted.
 
       operationId: createSession


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction
* documentation

#### What this PR does / why we need it:

Clarifying that only the `qosStatus` can be polled, but not the `statusInfo` which is provided only within `EventQosStatusChanged`


#### Which issue(s) this PR fixes:

This documentation patch does not fix the issue #267 finally.

#### Special notes for reviewers:

While creating this PR, I'm not any more sure that we should fix the issue in this way, even short-term. Instead there is the option to create a patch release v0.10.1 which adds the `statusInfo` also to `SessionInfo`.

Left the version number open for discussion.

#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
