### PR TITLE
Upping the checkout action in the swagger validation to remove a warning

### DIFF
--- a/.github/workflows/swagger-editor-validator.yml
+++ b/.github/workflows/swagger-editor-validator.yml
@@ -1,10 +1,10 @@
 ---
 name: Swagger Editor validation
 
-on:  # yamllint disable-line rule:truthy
-  pull_request:
-    branches:
-      - main
+on:  workflow_dispatch # yamllint disable-line rule:truthy
+  # pull_request:
+  #   branches:
+  #     - main
 
 jobs:
   test_swagger_editor_validator_remote:

--- a/.github/workflows/swagger-editor-validator.yml
+++ b/.github/workflows/swagger-editor-validator.yml
@@ -1,10 +1,10 @@
 ---
 name: Swagger Editor validation
 
-on:  workflow_dispatch # yamllint disable-line rule:truthy
-  # pull_request:
-  #   branches:
-  #     - main
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test_swagger_editor_validator_remote:

--- a/.github/workflows/swagger-editor-validator.yml
+++ b/.github/workflows/swagger-editor-validator.yml
@@ -1,4 +1,6 @@
 ---
+name: Swagger Editor validation
+
 on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
@@ -10,7 +12,7 @@ jobs:
     name: Swagger Editor Validator Remote
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
         uses: char0n/swagger-editor-validate@v1.3.2
         with:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* cleanup


#### What this PR does / why we need it:

The swagger validation action was missing a name, and this is added here:

<img width="314" alt="image" src="https://github.com/camaraproject/QualityOnDemand/assets/1710385/8610dc9a-4434-4597-b7ed-c5118d354d83">

Becomes:

<img width="236" alt="image" src="https://github.com/camaraproject/QualityOnDemand/assets/1710385/1d596ddd-4c7f-4dc5-8b15-822c0f3db1f4">

Also this action was using v3 of the checkout action, giving a warning suggesting an upgrade to v4.

<img width="1574" alt="image" src="https://github.com/camaraproject/QualityOnDemand/assets/1710385/d9ec4ea0-d022-4c9d-8206-96ffb982f16f">

This upgrades the action version to remove this warning.


#### Which issue(s) this PR fixes:

No issue raised as this is a cleanup PR

#### Special notes for reviewers:

None

#### Changelog input

No changeling needed - this is an internal change

