### PR TITLE
Update MAINTAINERS.MD - Added GitHub names

### DIFF
--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -9,6 +9,6 @@
 | Telefonica | Jesus Peña| jpengar |
 | Vodafone | Eric Murray | eric-murray |
 | Verizon/ 5GFF| Syed Rehman | SyeddR |
-| Verizon/ 5GFF| Mahesh Chapalamadugu | |
+| Verizon/ 5GFF| Mahesh Chapalamadugu | maheshc01 |
 | KDDI | Toshi (Toshiyasu) Wakayama | ToshiWakayama-KDDI |
 | CableLabs | Randy Levensalor | RandyLevensalor |

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -1,14 +1,14 @@
-| Org                    | Name                                                |
-| -----------------------| ----------------------------------------------------|
-| Deutsche Telekom AG | Herbert Damker |
-| Ericsson | Emil Zhang |
-| Orange | Sylvain Morel |
-| Orange | Patrice Conil |
-| Spry Fox Networks | Ramesh Shanmugasundaram |
-| Telefonica | Jose Luis Urien |
-| Telefonica | Jesus Peña| 
-| Vodafone | Eric Murray |
-| Verizon/ 5GFF| Syed Rehman |
-| Verizon/ 5GFF| Mahesh Chapalamadugu |
-| KDDI | Toshi (Toshiyasu) Wakayama |
-| CableLabs | Randy Levensalor |
+| Org                    | Name                 | GitHub Name        |
+| -----------------------| -------------------- | ------------------ |
+| Deutsche Telekom AG | Herbert Damker | hdamker |
+| Ericsson | Emil Zhang | emil-cheung |
+| Orange | Sylvain Morel | SylMOREL |
+| Orange | Patrice Conil | patrice-conil |
+| Spry Fox Networks | Ramesh Shanmugasundaram | sfnuser |
+| Telefonica | Jose Luis Urien | jlurien |
+| Telefonica | Jesus Peña| jpengar |
+| Vodafone | Eric Murray | eric-murray |
+| Verizon/ 5GFF| Syed Rehman | SyeddR |
+| Verizon/ 5GFF| Mahesh Chapalamadugu | |
+| KDDI | Toshi (Toshiyasu) Wakayama | ToshiWakayama-KDDI |
+| CableLabs | Randy Levensalor | RandyLevensalor |


### PR DESCRIPTION

#### What type of PR is this?

Add one of the following kinds:

* subproject management

#### What this PR does / why we need it:

Collected the GitHub names to be able to invite the right people into the quality-on-demand_maintainer team.

As part of the CAMARA organisation improvements we are creating groups for the maintainers and codeowners of all sub projects. As part of this, we have collected the GitHub names of the sub project maintainers to invite the right people.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
