### PR TITLE
Add error 429 QUOTA_EXCEEDED

### DIFF
--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -252,6 +252,23 @@ paths:
                 status: 409
                 code: CONFLICT
                 message: "Another session is created for the same device"
+        "429":
+          description: Rate limit or quota exceeded
+          headers:
+            x-correlator:
+              $ref: '#/components/headers/x-correlator'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorInfo"
+              examples:
+                QuotaExceeded:
+                  summary: Quota exceeded
+                  description: The requested duration exceeds the overall sessions time cap for this device or application, in certain period of time or contract duration.
+                  value:
+                    status: 429
+                    code: QUOTA_EXCEEDED
+                    message: "Requested duration exceeds the contracted quota for the current device"
         "500":
           $ref: "#/components/responses/Generic500"
         "501":


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature


#### What this PR does / why we need it:

Adds a new error scenario to be used when a server logic rejects a request to create a session due to a business quota being exceeded.

Added a subcase for 429 with a new specific code QUOTA_EXCEEDED


#### Which issue(s) this PR fixes:

Fixes #257 

#### Special notes for reviewers:

403 could have been used instead, as a general forbidden due to business rules, but 429 is more related to cases where rate or quota limits are exceeded. But this could be open to debate as guidelines are not explicit about this case. It is related with the discussion for Commonalities PR https://github.com/camaraproject/Commonalities/pull/213

#### Changelog input

```
Added explicit error response status 429 to createSessions

```
