### PR TITLE
Make + prefix mandatory for phoneNumber

### DIFF
--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -775,7 +775,7 @@ components:
       type: string
       pattern: '^\+[1-9][0-9]{4,14}$'
       example: "+123456789"
-      
+
     DeviceIpv4Addr:
       type: object
       description: |

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -771,11 +771,11 @@ components:
       example: "123456789@domain.com"
 
     PhoneNumber:
-      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, optionally prefixed with '+'.
+      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
       type: string
-      pattern: '^\+?[0-9]{5,15}$'
-      example: "123456789"
-
+      pattern: '^\+[1-9][0-9]{4,14}$'
+      example: "+123456789"
+      
     DeviceIpv4Addr:
       type: object
       description: |


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Alignment with Commonalities about + prefix for international E.164 phoneNumbers 

#### Which issue(s) this PR fixes:

Fixes #298 

