### PR TITLE
Remove unused messages object in SessionInfo schema

### DIFF
--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -549,10 +549,6 @@ components:
               $ref: "#/components/schemas/QosStatus"
             statusInfo:
               $ref: "#/components/schemas/StatusInfo"
-            messages:
-              type: array
-              items:
-                $ref: "#/components/schemas/Message"
           required:
             - sessionId
             - duration
@@ -834,21 +830,6 @@ components:
           - address/mask - an IP v6 number with a mask:
             - 2001:db8:85a3:8d3::0/64
             - 2001:db8:85a3:8d3::/64
-
-    Message:
-      description: Message with additional information
-      type: object
-      properties:
-        severity:
-          description: Message severity
-          type: string
-          enum: ["INFO", "WARNING"]
-        description:
-          description: Detailed message text
-          type: string
-      required:
-        - severity
-        - description
 
     QosStatus:
       description: |


### PR DESCRIPTION
#### What type of PR is this?
* correction
#### What this PR does / why we need it:
* Remove unused `messages` object in the `SessionInfo` schema
#### Which issue(s) this PR fixes:

Fixes #309

#### Special notes for reviewers:
As discussed in today's [call](https://wiki.camaraproject.org/display/CAM/2024-06-28+Quality+on+Demand+-+Meeting+Minutes) 

#### Changelog input

```
Removed unused `messages` object in the `SessionInfo` schema
```




