### PR TITLE
List sessions endpoint for quality-on-demand

### DIFF
--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -487,7 +487,7 @@ paths:
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "#/components/responses/Generic404"
+          $ref: "#/components/responses/GenericDevice404"
         "422":
           $ref: "#/components/responses/Generic422"
         "429":

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -445,14 +445,16 @@ paths:
     post:
       tags:
         - QoS Sessions
-      summary: Get all QoS session information for a given device
+      summary: Get QoS session information for a device
       description: |
-        Querying for QoS session resource information details for a given device
+        Querying for QoS session resource information details for a device
 
         **NOTES:**
-        - The access token may be either 2-legged or 3-legged. If a 3-legged access token is used, the end user associated with the session must also be associated with the access token.
-        - If a 2-legged access token is used, all returned sessions must have been created by the same API client given in the access token.
-        - If no QoS session is found for the device, an empty array is returned.
+        - The access token may be either 2-legged or 3-legged.
+          - If a 3-legged access token is used, the end user (and device) associated with the session must also be associated with the access token. In this case it is recommended NOT to include the `device` parameter in the request (see "Handling of device information" within the API description for details).
+          - If a 2-legged access token is used, the device parameter must be provided and identify a device.
+        - The session must have been created by the same API client given in the access token
+        - If no QoS session is found for the requested device, an empty array is returned.
       operationId: retrieveSessions
       parameters:
         - $ref: "#/components/parameters/x-correlator"
@@ -474,8 +476,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/RetrieveSessionsOutput"
               examples:
-                PROVISIONING_AVAILABLE:
+                RETRIEVE_SESSIONS_ONE_ITEM:
                   $ref: "#/components/examples/RETRIEVE_SESSIONS_EXAMPLE"
+                RETRIEVE_SESSIONS_NO_ITEMS:
+                  $ref: "#/components/examples/RETRIEVE_SESSIONS_EMPTY_EXAMPLE"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -486,6 +490,8 @@ paths:
           $ref: "#/components/responses/Generic404"
         "422":
           $ref: "#/components/responses/Generic422"
+        "429":
+          $ref: "#/components/responses/Generic429"
         "500":
           $ref: "#/components/responses/Generic500"
         "503":
@@ -927,8 +933,6 @@ components:
     RetrieveSessionsInput:
       description: Parameters to get QoS session information by device
       type: object
-      required:
-        - device
       properties:
         device:
           $ref: "#/components/schemas/Device"
@@ -1184,3 +1188,8 @@ components:
           startedAt: "2024-06-01T12:00:00Z"
           expiresAt: "2024-06-01T13:00:00Z"
           qosStatus: AVAILABLE
+
+    RETRIEVE_SESSIONS_EMPTY_EXAMPLE:
+      summary: No sessions found for the device
+      description: An empty array is returned when no sessions are found for the device
+      value: []

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -442,7 +442,7 @@ paths:
         "503":
           $ref: "#/components/responses/Generic503"
 
-  /sessions/retrieve:
+  /retrieve-sessions:
     post:
       tags:
         - QoS Sessions
@@ -452,6 +452,7 @@ paths:
 
         **NOTES:**
         - The access token may be either 2-legged or 3-legged. If a 3-legged access token is used, the end user associated with the session must also be associated with the access token.
+        - If a 2-legged access token is used, all returned sessions must have been created by the same API client given in the access token.
         - If no QoS session is found for the device, an empty array is returned.
       operationId: retrieveSessions
       parameters:
@@ -492,7 +493,7 @@ paths:
           $ref: "#/components/responses/Generic503"
       security:
         - openId:
-            - "quality-on-demand:sessions:read"
+            - "quality-on-demand:sessions:retrieve-by-device"
 
 components:
   securitySchemes:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -464,7 +464,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/RetrieveSessionsInput"
-        required: true
       responses:
         "200":
           description: Returns the QoS sessions information for a given device. A device may have multiple sessions, thus the response is an array. An empty array is returned if no sessions are found.

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -464,6 +464,7 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/RetrieveSessionsInput"
+        required: true
       responses:
         "200":
           description: Returns the QoS sessions information for a given device. A device may have multiple sessions, thus the response is an array. An empty array is returned if no sessions are found.

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -981,6 +981,20 @@ components:
             code: PERMISSION_DENIED
             message: "Operation not allowed: ..."
 
+    SessionNotFound404:
+      description: Session not found
+      headers:
+        x-correlator:
+          $ref: '#/components/headers/x-correlator'
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          example:
+            status: 404
+            code: NOT_FOUND
+            message: "Session Id does not exist"
+
     Generic404:
       description: Not found
       headers:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -1013,38 +1013,6 @@ components:
                 code: DEVICE_NOT_FOUND
                 message: Device identifier not found.
 
-    Generic404:
-      description: Not found
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInfo"
-          examples:
-            GENERIC_404_NOT_FOUND:
-              summary: Generic Not Found
-              description: Resource is not found
-              value:
-                status: 404
-                code: NOT_FOUND
-                message: "{{resource}} is not found"
-
-    Generic422:
-      description: Unprocessable entity
-      headers:
-        x-correlator:
-          $ref: '#/components/headers/x-correlator'
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInfo"
-          example:
-            status: 422
-            code: UNPROCESSABLE_ENTITY
-            message: "Value not acceptable: ..."
-
     SessionInConflict409:
       description: Conflict
       headers:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -455,7 +455,7 @@ paths:
           - If a 2-legged access token is used, the device parameter must be provided and identify a device.
         - The session must have been created by the same API client given in the access token
         - If no QoS session is found for the requested device, an empty array is returned.
-      operationId: retrieveSessions
+      operationId: retrieveSessionsByDevice
       parameters:
         - $ref: "#/components/parameters/x-correlator"
       requestBody:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -312,7 +312,7 @@ paths:
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "#/components/responses/SessionNotFound404"
+          $ref: "#/components/responses/Generic404"
         "500":
           $ref: "#/components/responses/Generic500"
         "503":
@@ -358,7 +358,7 @@ paths:
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "#/components/responses/SessionNotFound404"
+          $ref: "#/components/responses/Generic404"
         "500":
           $ref: "#/components/responses/Generic500"
         "503":
@@ -436,11 +436,63 @@ paths:
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "#/components/responses/SessionNotFound404"
+          $ref: "#/components/responses/Generic404"
         "500":
           $ref: "#/components/responses/Generic500"
         "503":
           $ref: "#/components/responses/Generic503"
+
+  /sessions/retrieve:
+    post:
+      tags:
+        - QoS Sessions
+      summary: Get all QoS session information for a given device
+      description: |
+        Querying for QoS session resource information details for a given device
+
+        **NOTES:**
+        - The access token may be either 2-legged or 3-legged. If a 3-legged access token is used, the end user associated with the session must also be associated with the access token.
+        - If no QoS session is found for the device, an empty array is returned.
+      operationId: retrieveSessions
+      parameters:
+        - $ref: "#/components/parameters/x-correlator"
+      requestBody:
+        description: Parameters to get QoS session information by device
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RetrieveSessionsInput"
+        required: true
+      responses:
+        "200":
+          description: Returns the QoS sessions information for a given device. A device may have multiple sessions, thus the response is an array. An empty array is returned if no sessions are found.
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RetrieveSessionsOutput"
+              examples:
+                PROVISIONING_AVAILABLE:
+                  $ref: "#/components/examples/RETRIEVE_SESSIONS_EXAMPLE"
+        "400":
+          $ref: "#/components/responses/Generic400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/Generic404"
+        "422":
+          $ref: "#/components/responses/Generic422"
+        "500":
+          $ref: "#/components/responses/Generic500"
+        "503":
+          $ref: "#/components/responses/Generic503"
+      security:
+        - openId:
+            - "quality-on-demand:sessions:read"
 
 components:
   securitySchemes:
@@ -872,6 +924,22 @@ components:
         - code
         - message
 
+    RetrieveSessionsInput:
+      description: Parameters to get QoS session information by device
+      type: object
+      required:
+        - device
+      properties:
+        device:
+          $ref: "#/components/schemas/Device"
+
+    RetrieveSessionsOutput:
+      description: QoS session information for a given device
+      type: array
+      items:
+        $ref: "#/components/schemas/SessionInfo"
+      minItems: 0
+
   responses:
     Generic400:
       description: Invalid input
@@ -915,8 +983,26 @@ components:
             code: PERMISSION_DENIED
             message: "Operation not allowed: ..."
 
-    SessionNotFound404:
-      description: Session not found
+    Generic404:
+      description: Not found
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          examples:
+            GENERIC_404_NOT_FOUND:
+              summary: Generic Not Found
+              description: Resource is not found
+              value:
+                status: 404
+                code: NOT_FOUND
+                message: "{{resource}} is not found"
+
+    Generic422:
+      description: Unprocessable entity
       headers:
         x-correlator:
           $ref: '#/components/headers/x-correlator'
@@ -925,9 +1011,9 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorInfo"
           example:
-            status: 404
-            code: NOT_FOUND
-            message: "Session Id does not exist"
+            status: 422
+            code: UNPROCESSABLE_ENTITY
+            message: "Value not acceptable: ..."
 
     Generic500:
       description: Internal server error
@@ -1024,3 +1110,20 @@ components:
           sessionId: '123e4567-e89b-12d3-a456-426614174000'
           qosStatus: 'UNAVAILABLE'
           statusInfo: 'DURATION_EXPIRED'
+
+    RETRIEVE_SESSIONS_EXAMPLE:
+      summary: List of QoS sessions for the device
+      description: A single QoS session for the device is available
+      value:
+        - duration: 3600
+          device:
+            phoneNumber: "+123456789"
+          applicationServer:
+            ipv4Address: 0.0.0.0/0
+          qosProfile: QOS_L
+          webhook:
+            notificationUrl: https://application-server.com
+          sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+          startedAt: "2024-06-01T12:00:00Z"
+          expiresAt: "2024-06-01T13:00:00Z"
+          qosStatus: AVAILABLE


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Adds a new endpoint to return a list of sessions for a given device, thus it will be possible to look for sessions for a given device without knowing the assigned sessionId.


#### Which issue(s) this PR fixes:

Fixes #101 

#### Special notes for reviewers:

Deprecates PR #228

I have made device required in the input, to be aligned with the rest of the API in this PR. There is a separate issue #313 to decide on the alignment of the API with the guidelines regarding device identification and making it optional in the request body.

#### Changelog input

```
* New operation retrieveSessions to get a list of sessions for a given device
```

#### Additional documentation 

