### PR TITLE
Updating names qos-profile of endpoints

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -75,17 +75,21 @@ tags:
     description: Manage QoS Profiles
 
 paths:
-  /qos-profiles:
+  /retrieve-qos-profiles:
     post:
       tags:
         - QoS Profiles
-      summary: Get QoS profiles available for a given device
+      summary: Retrieve QoS profiles
       description: |
         Returns all QoS Profiles that match the given criteria.
         **NOTES:**
         - The access token may be either a 2-legged or 3-legged access token.
         - If the access token is 3-legged, all returned QoS Profiles will be available to all end users associated with the access token.
-      operationId: qosProfilesDevice
+
+      security:
+        - openId:
+            - qos-profiles:read
+      operationId: retrieveQoSProfilesByDevice
       parameters:
         - $ref: "#/components/parameters/x-correlator"
       requestBody:
@@ -124,12 +128,12 @@ paths:
         "503":
           $ref: "#/components/responses/Generic503"
 
-  /qos-profiles/{name}:
+  /retrieve-qos-profile/{name}:
     get:
       tags:
         - QoS Profiles
       summary: "Get QoS Profile for a given name"
-      operationId: getQosProfile
+      operationId: retrieveQosProfile
       description: |
         Returns a QoS Profile that matches the given name.
 
@@ -137,7 +141,7 @@ paths:
 
       security:
         - openId:
-            - qos-profiles:qos-profiles:read
+            - qos-profiles:read
       parameters:
         - name: name
           in: path

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -128,7 +128,7 @@ paths:
         "503":
           $ref: "#/components/responses/Generic503"
 
-  /retrieve-qos-profile/{name}:
+  /retrieve-qos-profiles/{name}:
     get:
       tags:
         - QoS Profiles
@@ -141,7 +141,7 @@ paths:
 
       security:
         - openId:
-            - qos-profiles:retrieve-qos-profiles
+            - qos-profiles:read
       parameters:
         - name: name
           in: path

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -89,7 +89,7 @@ paths:
       security:
         - openId:
             - qos-profiles:read
-      operationId: retrieveQoSProfilesByDevice
+      operationId: retrieveQoSProfiles
       parameters:
         - $ref: "#/components/parameters/x-correlator"
       requestBody:
@@ -128,12 +128,12 @@ paths:
         "503":
           $ref: "#/components/responses/Generic503"
 
-  /retrieve-qos-profiles/{name}:
+  /qos-profiles/{name}:
     get:
       tags:
         - QoS Profiles
       summary: "Get QoS Profile for a given name"
-      operationId: retrieveQosProfile
+      operationId: getQosProfile
       description: |
         Returns a QoS Profile that matches the given name.
 

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -141,7 +141,7 @@ paths:
 
       security:
         - openId:
-            - qos-profiles:read
+            - qos-profiles:retrieve-qos-profiles
       parameters:
         - name: name
           in: path


### PR DESCRIPTION

#### What type of PR is this?

Add one of the following kinds:
* correction

#### What this PR does / why we need it:

Updates the endpoint names to include a verb.

Adds security scope to /retrieve-qos-profiles

Updates security scope on /retrieve-qos-profiles/{name}


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #345

#### Special notes for reviewers:

Should `/retrieve-qos-profiles/{name}` be singular `/retrieve-qos-profile/{name}` since it only returns a single qos-profile.

#### Changelog input

```
 release-note

Update qos-profile endpoint names to align with commonalites.  Updates the endpoint names to include a verb.

`/qos-profiles` is now `/retrieve-qos-profiles` and `/qos-profiles/{name}` is now `/retrieve-qos-profiles/{name}`


```

#### Additional documentation 

This section can be blank.



```
docs

```
