### PR TITLE
Updating the notes for the retrieve POST calls

### DIFF
--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -304,6 +304,9 @@ paths:
           - If a 2-legged access token is used, the device parameter must be provided and identify a device.
         - The QoD provisioning must have been created by the same API client given in the access token.
         - If no provisioning is found for the device, an error response 404 is returned with code "NOT_FOUND".
+        - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET. Additionally, this call may include complex data structures.
+          [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
+
       operationId: retrieveProvisioningByDevice
       parameters:
         - $ref: "#/components/parameters/x-correlator"

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -305,7 +305,7 @@ paths:
         - The QoD provisioning must have been created by the same API client given in the access token.
         - If no provisioning is found for the device, an error response 404 is returned with code "NOT_FOUND".
         - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET.
-          [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
+          [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/r0.4.0/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
 
       operationId: retrieveProvisioningByDevice
       parameters:

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -304,7 +304,7 @@ paths:
           - If a 2-legged access token is used, the device parameter must be provided and identify a device.
         - The QoD provisioning must have been created by the same API client given in the access token.
         - If no provisioning is found for the device, an error response 404 is returned with code "NOT_FOUND".
-        - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET.
+        - This call uses the POST method instead of GET to comply with the [CAMARA Commonalities guidelines](https://github.com/camaraproject/Commonalities/blob/r0.4.0/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data) for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET.
           [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/r0.4.0/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
 
       operationId: retrieveProvisioningByDevice

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -304,7 +304,7 @@ paths:
           - If a 2-legged access token is used, the device parameter must be provided and identify a device.
         - The QoD provisioning must have been created by the same API client given in the access token.
         - If no provisioning is found for the device, an error response 404 is returned with code "NOT_FOUND".
-        - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET. Additionally, this call may include complex data structures.
+        - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET.
           [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
 
       operationId: retrieveProvisioningByDevice

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -305,7 +305,6 @@ paths:
         - The QoD provisioning must have been created by the same API client given in the access token.
         - If no provisioning is found for the device, an error response 404 is returned with code "NOT_FOUND".
         - This call uses the POST method instead of GET to comply with the [CAMARA Commonalities guidelines](https://github.com/camaraproject/Commonalities/blob/r0.4.0/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data) for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET.
-          [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/r0.4.0/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
 
       operationId: retrieveProvisioningByDevice
       parameters:

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -85,6 +85,8 @@ paths:
         **NOTES:**
         - The access token may be either a 2-legged or 3-legged access token.
         - If the access token is 3-legged, all returned QoS Profiles will be available to all end users associated with the access token.
+        - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET. Additionally, this call may include complex data structures.
+          [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
 
       security:
         - openId:

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -86,7 +86,7 @@ paths:
         - The access token may be either a 2-legged or 3-legged access token.
         - If the access token is 3-legged, all returned QoS Profiles will be available to all end users associated with the access token.
         - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET. Additionally, this call may include complex data structures.
-          [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
+          [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/r0.4.0/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
 
       security:
         - openId:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -408,6 +408,9 @@ paths:
           - If a 2-legged access token is used, the device parameter must be provided and identify a device.
         - The session must have been created by the same API client given in the access token
         - If no QoS session is found for the requested device, an empty array is returned.
+        - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET. Additionally, this call may include complex data structures.
+          [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
+
       operationId: retrieveSessionsByDevice
       parameters:
         - $ref: "#/components/parameters/x-correlator"

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -408,7 +408,7 @@ paths:
           - If a 2-legged access token is used, the device parameter must be provided and identify a device.
         - The session must have been created by the same API client given in the access token
         - If no QoS session is found for the requested device, an empty array is returned.
-        - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET. Additionally, this call may include complex data structures.
+        - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET.
           [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
 
       operationId: retrieveSessionsByDevice

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -409,7 +409,7 @@ paths:
         - The session must have been created by the same API client given in the access token
         - If no QoS session is found for the requested device, an empty array is returned.
         - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET.
-          [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
+          [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/r0.4.0/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
 
       operationId: retrieveSessionsByDevice
       parameters:


### PR DESCRIPTION
Fixes issues Add explanation on why there is a "POST /retrieve-sessions" instead of GET #359


#### What type of PR is this?

Add one of the following kinds:
* documentation


#### What this PR does / why we need it:

Clarifies why a POST call is used of a GET to retrieve data from the QoD APIs.

#### Which issue(s) this PR fixes:


Fixes #359 

#### Special notes for reviewers:



#### Changelog input

```
Added notes to retrieve POST calls to explain why these are a POST instead of a GET.
```

#### Additional documentation 

This section can be blank.



```
docs

```
