### PR TITLE
Update error responses and test cases to comply with Commonalities 0.5.0

### DIFF
--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -61,7 +61,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.5.0
+  x-camara-commonalities: 0.5
 
 externalDocs:
   description: Project documentation at CAMARA

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -34,29 +34,19 @@ info:
 
     It is important to remark that in cases where personal user data is processed by the API, and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of 3-legged access tokens becomes mandatory. This measure ensures that the API remains in strict compliance with user privacy preferences and regulatory obligations, upholding the principles of transparency and user-centric data control.
 
-    # Identifying a device from the access token
+    # Identifying the device from the access token
 
-    This specification defines the `device` object field as optional in API requests, specifically in cases where the API is accessed using a 3-legged access token, and the device can be uniquely identified by the token. This approach simplifies API usage for API consumers by relying on the device information associated with the access token used to invoke the API.
+    This API requires the API consumer to identify a device as the subject of the API as follows:
+    - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
 
-    ## Handling of device information:
+    - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.
 
-    ### Optional device object for 3-legged tokens:
+    This approach simplifies API usage for API consumers using a three-legged access token to invoke the API by relying on the information that is associated with the access token and was identified during the authentication process.
 
-    - When using a 3-legged access token, the device associated with the access token must be considered as the device for the API request. This means that the device object is not required in the request, and if included it must identify the same device, therefore **it is recommended NOT to include it in these scenarios** to simplify the API usage and avoid additional validations.
+    ## Error handling:
+    - If the subject cannot be identified from the access token and the optional `device` object is not included in the request, then the server will return an error with the `422 MISSING_IDENTIFIER` error code.
 
-    ### Validation mechanism:
-
-    - The server will extract the device identification from the access token, if available.
-    - If the API request additionally includes a `device` object when using a 3-legged access token, the API will validate that the device identifier provided matches the one associated with the access token.
-    - If there is a mismatch, the API will respond with a 403 - INVALID_TOKEN_CONTEXT error, indicating that the device information in the request does not match the token.
-
-    ### Error handling for unidentifiable devices:
-
-    - If the `device` object is not included in the request and the device information cannot be derived from the 3-legged access token, the server will return a 422 `UNIDENTIFIABLE_DEVICE` error.
-
-    ### Restrictions for tokens without an associated authenticated identifier:
-
-    - For scenarios which do not have a single device identifier associated to the token during the authentication flow, e.g. 2-legged access tokens, the `device` object MUST be provided in the API request. This ensures that the device identification is explicit and valid for each API call made with these tokens.
+    - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
 
     # Multi-SIM scenario handling
 

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -1083,7 +1083,7 @@ components:
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
           accessTokenType: bearer
         provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
-        startedAt: 2024-05-12T17:32:01Z
+        startedAt: "2024-05-12T17:32:01Z"
         status: AVAILABLE
 
     PROVISIONING_UNAVAILABLE:
@@ -1103,7 +1103,7 @@ components:
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
           accessTokenType: bearer
         provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
-        startedAt: 2024-05-12T17:32:01Z
+        startedAt: "2024-05-12T17:32:01Z"
         status: UNAVAILABLE
         statusInfo: NETWORK_TERMINATED
 
@@ -1119,7 +1119,7 @@ components:
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
           accessTokenType: bearer
         provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
-        startedAt: 2024-05-12T17:32:01Z
+        startedAt: "2024-05-12T17:32:01Z"
         status: AVAILABLE
 
     PROVISIONING_STATUS_CHANGED_EXAMPLE:
@@ -1130,7 +1130,7 @@ components:
         source: https://api.example.com/qod-provisioning/v0.1/device-qos/123e4567-e89b-12d3-a456-426614174000
         specversion: "1.0"
         type: org.camaraproject.qod-provisioning.v0.status-changed
-        time: 2021-12-12T00:00:00Z
+        time: "2021-12-12T00:00:00Z"
         data:
           provisioningId: 123e4567-e89b-12d3-a456-426614174000
           status: UNAVAILABLE

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -71,7 +71,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.4.0
+  x-camara-commonalities: 0.5.0
 
 externalDocs:
   description: Project documentation at CAMARA
@@ -157,10 +157,6 @@ paths:
                   $ref: "#/components/responses/Generic410"
                 "429":
                   $ref: "#/components/responses/Generic429"
-                "500":
-                  $ref: "#/components/responses/Generic500"
-                "503":
-                  $ref: "#/components/responses/Generic503"
               security:
                 - {}
                 - notificationsBearerAuth: []
@@ -188,10 +184,6 @@ paths:
           $ref: "#/components/responses/Generic422"
         "429":
           $ref: "#/components/responses/Generic429"
-        "500":
-          $ref: "#/components/responses/Generic500"
-        "503":
-          $ref: "#/components/responses/Generic503"
       security:
         - openId:
             - "qod-provisioning:device-qos:create"
@@ -239,10 +231,6 @@ paths:
           $ref: "#/components/responses/Generic404"
         "429":
           $ref: "#/components/responses/Generic429"
-        "500":
-          $ref: "#/components/responses/Generic500"
-        "503":
-          $ref: "#/components/responses/Generic503"
       security:
         - openId:
             - "qod-provisioning:device-qos:read"
@@ -292,10 +280,6 @@ paths:
           $ref: "#/components/responses/Generic404"
         "429":
           $ref: "#/components/responses/Generic429"
-        "500":
-          $ref: "#/components/responses/Generic500"
-        "503":
-          $ref: "#/components/responses/Generic503"
       security:
         - openId:
             - "qod-provisioning:device-qos:delete"
@@ -353,10 +337,6 @@ paths:
           $ref: "#/components/responses/Generic422"
         "429":
           $ref: "#/components/responses/Generic429"
-        "500":
-          $ref: "#/components/responses/Generic500"
-        "503":
-          $ref: "#/components/responses/Generic503"
       security:
         - openId:
             - "qod-provisioning:device-qos:read-by-device"
@@ -771,7 +751,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               description: Invalid Argument. Generic Syntax Exception
@@ -794,7 +784,19 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
+                      - INVALID_CREDENTIAL
+                      - INVALID_TOKEN
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               description: Invalid Argument. Generic Syntax Exception
@@ -811,13 +813,13 @@ components:
             GENERIC_400_INVALID_CREDENTIAL:
               value:
                 status: 400
-                code: "INVALID_CREDENTIAL"
-                message: "Only Access token is supported"
+                code: INVALID_CREDENTIAL
+                message: Only Access token is supported
             GENERIC_400_INVALID_TOKEN:
               value:
                 status: 400
-                code: "INVALID_TOKEN"
-                message: "Only bearer token is supported"
+                code: INVALID_TOKEN
+                message: Only bearer token is supported
 
     Generic401:
       description: Unauthorized
@@ -827,7 +829,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 401
+                  code:
+                    enum:
+                      - UNAUTHENTICATED
+                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
               description: Request cannot be authenticated
@@ -850,7 +862,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 403
+                  code:
+                    enum:
+                      - PERMISSION_DENIED
           examples:
             GENERIC_403_PERMISSION_DENIED:
               description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
@@ -858,12 +879,6 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_INVALID_TOKEN_CONTEXT:
-              description: Reflect some inconsistency between information in some field of the API and the related OAuth2 Token
-              value:
-                status: 403
-                code: INVALID_TOKEN_CONTEXT
-                message: "{{field}} is not consistent with access token."
 
     Generic404:
       description: Not found
@@ -873,7 +888,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
           examples:
             GENERIC_404_NOT_FOUND:
               description: Resource is not found
@@ -890,7 +914,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+                      - IDENTIFIER_NOT_FOUND
           examples:
             GENERIC_404_NOT_FOUND:
               description: Resource is not found
@@ -902,7 +936,7 @@ components:
               description: Device identifier not found
               value:
                 status: 404
-                code: DEVICE_NOT_FOUND
+                code: IDENTIFIER_NOT_FOUND
                 message: Device identifier not found.
 
     ProvisioningConflict409:
@@ -913,14 +947,23 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 409
+                  code:
+                    enum:
+                      - CONFLICT
           examples:
             PROVISIONING_409_CONFLICT:
               description: The requested provisioning conflicts with an existing one
               value:
                 status: 409
                 code: CONFLICT
-                message: "There is another existing provisioning for the same device"
+                message: There is another existing provisioning for the same device
 
     Generic410:
       description: Gone
@@ -930,7 +973,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 410
+                  code:
+                    enum:
+                      - GONE
           examples:
             GENERIC_410_GONE:
               description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
@@ -947,38 +999,51 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 422
+                  code:
+                    enum:
+                      - IDENTIFIER_MISMATCH
+                      - SERVICE_NOT_APPLICABLE
+                      - MISSING_IDENTIFIER
+                      - UNSUPPORTED_IDENTIFIER
+                      - UNNECESSARY_IDENTIFIER
           examples:
-            GENERIC_422_UNPROCESSABLE_ENTITY:
-              description: The request was well-formed but was unable to be processed due to semantic errors or not applicable values. This is the generic error code for 422 responses.
+            GENERIC_422_IDENTIFIER_MISMATCH:
+              description: Inconsistency between identifiers not pointing to the same device
               value:
                 status: 422
-                code: UNPROCESSABLE_ENTITY
-                message: "Value not acceptable: ..."
-            GENERIC_422_DEVICE_IDENTIFIERS_MISMATCH:
-              description: Inconsistency between device identifiers not pointing to the same device
+                code: IDENTIFIER_MISMATCH
+                message: Provided identifiers are not consistent.
+            GENERIC_422_SERVICE_NOT_APPLICABLE:
+              description: Service not applicable for the provided identifier
               value:
                 status: 422
-                code: DEVICE_IDENTIFIERS_MISMATCH
-                message: Provided device identifiers are not consistent.
-            GENERIC_422_DEVICE_NOT_APPLICABLE:
-              description: Service is not available for the provided device
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not available for the provided identifier.
+            GENERIC_422_MISSING_IDENTIFIER:
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
               value:
                 status: 422
-                code: DEVICE_NOT_APPLICABLE
-                message: The service is not available for the provided device.
-            GENERIC_422_UNSUPPORTED_DEVICE_IDENTIFIERS:
-              description: Message may list the supported device identifiers
-              value:
-                status: 422
-                code: UNSUPPORTED_DEVICE_IDENTIFIERS
-                message: "Supported device supported are: ..."
-            GENERIC_422_UNIDENTIFIABLE_DEVICE:
-              description: Service is not available for the provided device
-              value:
-                status: 422
-                code: UNIDENTIFIABLE_DEVICE
+                code: MISSING_IDENTIFIER
                 message: The device cannot be identified.
+            GENERIC_422_UNSUPPORTED_IDENTIFIER:
+              description: None of the provided identifiers is supported by the implementation
+              value:
+                status: 422
+                code: UNSUPPORTED_IDENTIFIER
+                message: The identifier provided is not supported.
+            GENERIC_422_UNNECESSARY_IDENTIFIER:
+              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
+              value:
+                status: 422
+                code: UNNECESSARY_IDENTIFIER
+                message: The device is already identified by the access token.
 
     Generic429:
       description: Too Many Requests
@@ -988,7 +1053,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 429
+                  code:
+                    enum:
+                      - QUOTA_EXCEEDED
+                      - TOO_MANY_REQUESTS
           examples:
             GENERIC_429_QUOTA_EXCEEDED:
               description: Request is rejected due to exceeding a business quota limit
@@ -1002,40 +1077,6 @@ components:
                 status: 429
                 code: TOO_MANY_REQUESTS
                 message: Either out of resource quota or reaching rate limiting.
-
-    Generic500:
-      description: Internal server error
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInfo"
-          examples:
-            GENERIC_500_INTERNAL:
-              description: Problem in Server side. Regular Server Exception
-              value:
-                status: 500
-                code: INTERNAL
-                message: Unknown server error. Typically a server bug.
-
-    Generic503:
-      description: Service unavailable
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInfo"
-          examples:
-            GENERIC_503_UNAVAILABLE:
-              description: Service is not available. Temporary situation usually related to maintenance process in the server side
-              value:
-                status: 503
-                code: UNAVAILABLE
-                message: Service Unavailable.
 
   examples:
     PROVISIONING_AVAILABLE:

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -1027,7 +1027,7 @@ components:
                 code: SERVICE_NOT_APPLICABLE
                 message: The service is not available for the provided identifier.
             GENERIC_422_MISSING_IDENTIFIER:
-              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the access token
               value:
                 status: 422
                 code: MISSING_IDENTIFIER

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -53,7 +53,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.5.0
+  x-camara-commonalities: 0.5
 
 
 externalDocs:

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -712,7 +712,7 @@ components:
                 code: SERVICE_NOT_APPLICABLE
                 message: The service is not available for the provided identifier.
             GENERIC_422_MISSING_IDENTIFIER:
-              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the access token
               value:
                 status: 422
                 code: MISSING_IDENTIFIER

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -63,7 +63,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.4.0
+  x-camara-commonalities: 0.5.0
 
 
 externalDocs:
@@ -132,10 +132,6 @@ paths:
           $ref: "#/components/responses/Generic422"
         "429":
           $ref: "#/components/responses/Generic429"
-        "500":
-          $ref: "#/components/responses/Generic500"
-        "503":
-          $ref: "#/components/responses/Generic503"
 
   /qos-profiles/{name}:
     get:
@@ -179,10 +175,6 @@ paths:
           $ref: "#/components/responses/Generic404"
         "429":
           $ref: "#/components/responses/Generic429"
-        "500":
-          $ref: "#/components/responses/Generic500"
-        "503":
-          $ref: "#/components/responses/Generic503"
 
 components:
   securitySchemes:
@@ -541,7 +533,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               description: Invalid Argument. Generic Syntax Exception
@@ -564,7 +566,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 401
+                  code:
+                    enum:
+                      - UNAUTHENTICATED
+                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
               description: Request cannot be authenticated
@@ -587,7 +599,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 403
+                  code:
+                    enum:
+                      - PERMISSION_DENIED
           examples:
             GENERIC_403_PERMISSION_DENIED:
               description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
@@ -595,12 +616,6 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_INVALID_TOKEN_CONTEXT:
-              description: Reflect some inconsistency between information in some field of the API and the related OAuth2 Token
-              value:
-                status: 403
-                code: INVALID_TOKEN_CONTEXT
-                message: "{{field}} is not consistent with access token."
 
     Generic404:
       description: Not found
@@ -610,7 +625,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
           examples:
             GENERIC_404_NOT_FOUND:
               description: Resource is not found
@@ -627,7 +651,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+                      - IDENTIFIER_NOT_FOUND
           examples:
             GENERIC_404_NOT_FOUND:
               description: Resource is not found
@@ -639,7 +673,7 @@ components:
               description: Device identifier not found
               value:
                 status: 404
-                code: DEVICE_NOT_FOUND
+                code: IDENTIFIER_NOT_FOUND
                 message: Device identifier not found.
 
     Generic422:
@@ -650,26 +684,51 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 422
+                  code:
+                    enum:
+                      - IDENTIFIER_MISMATCH
+                      - SERVICE_NOT_APPLICABLE
+                      - MISSING_IDENTIFIER
+                      - UNSUPPORTED_IDENTIFIER
+                      - UNNECESSARY_IDENTIFIER
           examples:
-            GENERIC_422_DEVICE_IDENTIFIERS_MISMATCH:
-              description: Inconsistency between device identifiers not pointing to the same device
+            GENERIC_422_IDENTIFIER_MISMATCH:
+              description: Inconsistency between identifiers not pointing to the same device
               value:
                 status: 422
-                code: DEVICE_IDENTIFIERS_MISMATCH
-                message: Provided device identifiers are not consistent.
-            GENERIC_422_DEVICE_NOT_APPLICABLE:
-              description: Service is not available for the provided device
+                code: IDENTIFIER_MISMATCH
+                message: Provided identifiers are not consistent.
+            GENERIC_422_SERVICE_NOT_APPLICABLE:
+              description: Service not applicable for the provided identifier
               value:
                 status: 422
-                code: DEVICE_NOT_APPLICABLE
-                message: The service is not available for the provided device.
-            GENERIC_422_UNIDENTIFIABLE_DEVICE:
-              description: Service is not available for the provided device
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not available for the provided identifier.
+            GENERIC_422_MISSING_IDENTIFIER:
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
               value:
                 status: 422
-                code: UNIDENTIFIABLE_DEVICE
+                code: MISSING_IDENTIFIER
                 message: The device cannot be identified.
+            GENERIC_422_UNSUPPORTED_IDENTIFIER:
+              description: None of the provided identifiers is supported by the implementation
+              value:
+                status: 422
+                code: UNSUPPORTED_IDENTIFIER
+                message: The identifier provided is not supported.
+            GENERIC_422_UNNECESSARY_IDENTIFIER:
+              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
+              value:
+                status: 422
+                code: UNNECESSARY_IDENTIFIER
+                message: The device is already identified by the access token.
 
     Generic429:
       description: Too Many Requests
@@ -679,7 +738,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 429
+                  code:
+                    enum:
+                      - QUOTA_EXCEEDED
+                      - TOO_MANY_REQUESTS
           examples:
             GENERIC_429_QUOTA_EXCEEDED:
               description: Request is rejected due to exceeding a business quota limit
@@ -693,34 +762,3 @@ components:
                 status: 429
                 code: TOO_MANY_REQUESTS
                 message: Either out of resource quota or reaching rate limiting.
-
-    Generic500:
-      description: Internal server error
-      headers:
-        x-correlator:
-          $ref: '#/components/headers/x-correlator'
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInfo"
-          example:
-            status: 500
-            code: INTERNAL
-            message: "Internal server error: ..."
-
-    Generic503:
-      description: Service Unavailable
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInfo"
-          examples:
-            GENERIC_503_UNAVAILABLE:
-              description: Service is not available. Temporary situation usually related to maintenance process in the server side
-              value:
-                status: 503
-                code: UNAVAILABLE
-                message: Service Unavailable.

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -24,29 +24,19 @@ info:
 
     It is important to remark that in cases where personal user data is processed by the API, and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of 3-legged access tokens becomes mandatory. This measure ensures that the API remains in strict compliance with user privacy preferences and regulatory obligations, upholding the principles of transparency and user-centric data control.
 
-    # Identifying a device from the access token
+    # Identifying the device from the access token
 
-    This specification defines the `device` object field as optional in API requests, specifically in cases where the API is accessed using a 3-legged access token, and the device can be uniquely identified by the token. This approach simplifies API usage for API consumers by relying on the device information associated with the access token used to invoke the API.
+    This API requires the API consumer to identify a device as the subject of the API as follows:
+    - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
 
-    ## Handling of device information:
+    - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.
 
-    ### Optional device object for 3-legged tokens:
+    This approach simplifies API usage for API consumers using a three-legged access token to invoke the API by relying on the information that is associated with the access token and was identified during the authentication process.
 
-    - When using a 3-legged access token, the device associated with the access token must be considered as the device for the API request. This means that the device object is not required in the request, and if included it must identify the same device, therefore **it is recommended NOT to include it in these scenarios** to simplify the API usage and avoid additional validations.
+    ## Error handling:
+    - If the subject cannot be identified from the access token and the optional `device` object is not included in the request, then the server will return an error with the `422 MISSING_IDENTIFIER` error code.
 
-    ### Validation mechanism:
-
-    - The server will extract the device identification from the access token, if available.
-    - If the API request additionally includes a `device` object when using a 3-legged access token, the API will validate that the device identifier provided matches the one associated with the access token.
-    - If there is a mismatch, the API will respond with a 403 - INVALID_TOKEN_CONTEXT error, indicating that the device information in the request does not match the token.
-
-    ### Error handling for unidentifiable devices:
-
-    - If the `device` object is not included in the request and the device information cannot be derived from the 3-legged access token, the server will return a 422 `UNIDENTIFIABLE_DEVICE` error.
-
-    ### Restrictions for tokens without an associated authenticated identifier:
-
-    - For scenarios which do not have a single device identifier associated to the token during the authentication flow, e.g. 2-legged access tokens, the `device` object MUST be provided in the API request. This ensures that the device identification is explicit and valid for each API call made with these tokens.
+    - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
 
     # Multi-SIM scenario handling
 

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -1019,12 +1019,12 @@ components:
               value:
                 status: 400
                 code: INVALID_CREDENTIAL
-                message: "Only Access token is supported"
+                message: Only Access token is supported
             GENERIC_400_INVALID_TOKEN:
               value:
                 status: 400
                 code: INVALID_TOKEN
-                message: "Only bearer token is supported"
+                message: Only bearer token is supported
 
     GenericExtendSessionDuration400:
       description: Bad Request

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -105,7 +105,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.4.0
+  x-camara-commonalities: 0.5.0
 
 externalDocs:
   description: Project documentation at Camara
@@ -198,10 +198,6 @@ paths:
                   $ref: "#/components/responses/Generic403"
                 "410":
                   $ref: "#/components/responses/Generic410"
-                "500":
-                  $ref: "#/components/responses/Generic500"
-                "503":
-                  $ref: "#/components/responses/Generic503"
               security:
                 - {}
                 - notificationsBearerAuth: []
@@ -229,10 +225,6 @@ paths:
           $ref: "#/components/responses/Generic422"
         "429":
           $ref: "#/components/responses/Generic429"
-        "500":
-          $ref: "#/components/responses/Generic500"
-        "503":
-          $ref: "#/components/responses/Generic503"
 
   /sessions/{sessionId}:
     get:
@@ -284,10 +276,6 @@ paths:
           $ref: "#/components/responses/Generic404"
         "429":
           $ref: "#/components/responses/Generic429"
-        "500":
-          $ref: "#/components/responses/Generic500"
-        "503":
-          $ref: "#/components/responses/Generic503"
 
     delete:
       tags:
@@ -334,10 +322,6 @@ paths:
           $ref: "#/components/responses/Generic404"
         "429":
           $ref: "#/components/responses/Generic429"
-        "500":
-          $ref: "#/components/responses/Generic500"
-        "503":
-          $ref: "#/components/responses/Generic503"
 
   /sessions/{sessionId}/extend:
     post:
@@ -398,10 +382,6 @@ paths:
           $ref: "#/components/responses/SessionStatusConflict409"
         "429":
           $ref: "#/components/responses/Generic429"
-        "500":
-          $ref: "#/components/responses/Generic500"
-        "503":
-          $ref: "#/components/responses/Generic503"
 
   /retrieve-sessions:
     post:
@@ -457,10 +437,6 @@ paths:
           $ref: "#/components/responses/Generic422"
         "429":
           $ref: "#/components/responses/Generic429"
-        "500":
-          $ref: "#/components/responses/Generic500"
-        "503":
-          $ref: "#/components/responses/Generic503"
       security:
         - openId:
             - "quality-on-demand:sessions:retrieve-by-device"
@@ -1006,7 +982,20 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
+                      - QUALITY_ON_DEMAND.DURATION_OUT_OF_RANGE
+                      - INVALID_CREDENTIAL
+                      - INVALID_TOKEN
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               description: Invalid Argument. Generic Syntax Exception
@@ -1029,12 +1018,12 @@ components:
             GENERIC_400_INVALID_CREDENTIAL:
               value:
                 status: 400
-                code: "INVALID_CREDENTIAL"
+                code: INVALID_CREDENTIAL
                 message: "Only Access token is supported"
             GENERIC_400_INVALID_TOKEN:
               value:
                 status: 400
-                code: "INVALID_TOKEN"
+                code: INVALID_TOKEN
                 message: "Only bearer token is supported"
 
     GenericExtendSessionDuration400:
@@ -1045,7 +1034,18 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
+                      - QUALITY_ON_DEMAND.DURATION_OUT_OF_RANGE
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               description: Invalid Argument. Generic Syntax Exception
@@ -1074,7 +1074,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               description: Invalid Argument. Generic Syntax Exception
@@ -1097,7 +1107,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 401
+                  code:
+                    enum:
+                      - UNAUTHENTICATED
+                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
               description: Request cannot be authenticated
@@ -1120,7 +1140,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 403
+                  code:
+                    enum:
+                      - PERMISSION_DENIED
           examples:
             GENERIC_403_PERMISSION_DENIED:
               description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
@@ -1128,12 +1157,6 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_INVALID_TOKEN_CONTEXT:
-              description: Reflect some inconsistency between information in some field of the API and the related OAuth2 Token
-              value:
-                status: 403
-                code: INVALID_TOKEN_CONTEXT
-                message: "{{field}} is not consistent with access token."
 
     Generic404:
       description: Not found
@@ -1143,7 +1166,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
           examples:
             GENERIC_404_NOT_FOUND:
               description: Resource is not found
@@ -1160,7 +1192,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+                      - IDENTIFIER_NOT_FOUND
           examples:
             GENERIC_404_NOT_FOUND:
               description: Resource is not found
@@ -1172,7 +1214,7 @@ components:
               description: Device identifier not found
               value:
                 status: 404
-                code: DEVICE_NOT_FOUND
+                code: IDENTIFIER_NOT_FOUND
                 message: Device identifier not found.
 
     SessionInConflict409:
@@ -1183,7 +1225,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 409
+                  code:
+                    enum:
+                      - CONFLICT
           example:
             status: 409
             code: CONFLICT
@@ -1197,7 +1248,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 409
+                  code:
+                    enum:
+                      - QUALITY_ON_DEMAND.SESSION_EXTENSION_NOT_ALLOWED
           examples:
             SessionExtensionNotAllowed:
               description: Session extension is in conflict with current session status
@@ -1214,7 +1274,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 410
+                  code:
+                    enum:
+                      - GONE
           examples:
             GENERIC_410_GONE:
               description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
@@ -1231,26 +1300,51 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 422
+                  code:
+                    enum:
+                      - IDENTIFIER_MISMATCH
+                      - SERVICE_NOT_APPLICABLE
+                      - MISSING_IDENTIFIER
+                      - UNSUPPORTED_IDENTIFIER
+                      - UNNECESSARY_IDENTIFIER
           examples:
-            GENERIC_422_DEVICE_IDENTIFIERS_MISMATCH:
-              description: Inconsistency between device identifiers not pointing to the same device
+            GENERIC_422_IDENTIFIER_MISMATCH:
+              description: Inconsistency between identifiers not pointing to the same device
               value:
                 status: 422
-                code: DEVICE_IDENTIFIERS_MISMATCH
-                message: Provided device identifiers are not consistent.
-            GENERIC_422_DEVICE_NOT_APPLICABLE:
-              description: Service is not available for the provided device
+                code: IDENTIFIER_MISMATCH
+                message: Provided identifiers are not consistent.
+            GENERIC_422_SERVICE_NOT_APPLICABLE:
+              description: Service not applicable for the provided identifier
               value:
                 status: 422
-                code: DEVICE_NOT_APPLICABLE
-                message: The service is not available for the provided device.
-            GENERIC_422_UNIDENTIFIABLE_DEVICE:
-              description: Service is not available for the provided device
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not available for the provided identifier.
+            GENERIC_422_MISSING_IDENTIFIER:
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the access token
               value:
                 status: 422
-                code: UNIDENTIFIABLE_DEVICE
+                code: MISSING_IDENTIFIER
                 message: The device cannot be identified.
+            GENERIC_422_UNSUPPORTED_IDENTIFIER:
+              description: None of the provided identifiers is supported by the implementation
+              value:
+                status: 422
+                code: UNSUPPORTED_IDENTIFIER
+                message: The identifier provided is not supported.
+            GENERIC_422_UNNECESSARY_IDENTIFIER:
+              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
+              value:
+                status: 422
+                code: UNNECESSARY_IDENTIFIER
+                message: The device is already identified by the access token.
 
     Generic429:
       description: Too Many Requests
@@ -1260,7 +1354,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 429
+                  code:
+                    enum:
+                      - QUOTA_EXCEEDED
+                      - TOO_MANY_REQUESTS
           examples:
             GENERIC_429_QUOTA_EXCEEDED:
               description: Request is rejected due to exceeding a business quota limit
@@ -1274,37 +1378,6 @@ components:
                 status: 429
                 code: TOO_MANY_REQUESTS
                 message: Either out of resource quota or reaching rate limiting.
-
-    Generic500:
-      description: Internal server error
-      headers:
-        x-correlator:
-          $ref: '#/components/headers/x-correlator'
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInfo"
-          example:
-            status: 500
-            code: INTERNAL
-            message: "Internal server error: ..."
-
-    Generic503:
-      description: Service Unavailable
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInfo"
-          examples:
-            GENERIC_503_UNAVAILABLE:
-              description: Service is not available. Temporary situation usually related to maintenance process in the server side
-              value:
-                status: 503
-                code: UNAVAILABLE
-                message: Service Unavailable.
 
   examples:
     SESSION_AVAILABLE_EXAMPLE:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -95,7 +95,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.5.0
+  x-camara-commonalities: 0.5
 
 externalDocs:
   description: Project documentation at Camara

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -64,29 +64,19 @@ info:
 
     It is important to remark that in cases where personal user data is processed by the API, and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of 3-legged access tokens becomes mandatory. This measure ensures that the API remains in strict compliance with user privacy preferences and regulatory obligations, upholding the principles of transparency and user-centric data control.
 
-    # Identifying a device from the access token
+    # Identifying the device from the access token
 
-    This specification defines the `device` object field as optional in API requests, specifically in cases where the API is accessed using a 3-legged access token, and the device can be uniquely identified by the token. This approach simplifies API usage for API consumers by relying on the device information associated with the access token used to invoke the API.
+    This API requires the API consumer to identify a device as the subject of the API as follows:
+    - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
 
-    ## Handling of device information:
+    - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.
 
-    ### Optional device object for 3-legged tokens:
+    This approach simplifies API usage for API consumers using a three-legged access token to invoke the API by relying on the information that is associated with the access token and was identified during the authentication process.
 
-    - When using a 3-legged access token, the device associated with the access token must be considered as the device for the API request. This means that the device object is not required in the request, and if included it must identify the same device, therefore **it is recommended NOT to include it in these scenarios** to simplify the API usage and avoid additional validations.
+    ## Error handling:
+    - If the subject cannot be identified from the access token and the optional `device` object is not included in the request, then the server will return an error with the `422 MISSING_IDENTIFIER` error code.
 
-    ### Validation mechanism:
-
-    - The server will extract the device identification from the access token, if available.
-    - If the API request additionally includes a `device` object when using a 3-legged access token, the API will validate that the device identifier provided matches the one associated with the access token.
-    - If there is a mismatch, the API will respond with a 403 - INVALID_TOKEN_CONTEXT error, indicating that the device information in the request does not match the token.
-
-    ### Error handling for unidentifiable devices:
-
-    - If the `device` object is not included in the request and the device information cannot be derived from the 3-legged access token, the server will return a 422 `UNIDENTIFIABLE_DEVICE` error.
-
-    ### Restrictions for tokens without an associated authenticated identifier:
-
-    - For scenarios which do not have a single device identifier associated to the token during the authentication flow, e.g. 2-legged access tokens, the `device` object MUST be provided in the API request. This ensures that the device identification is explicit and valid for each API call made with these tokens.
+    - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
 
     # Multi-SIM scenario handling
 

--- a/code/Test_definitions/qod-provisioning-createProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-createProvisioning.feature
@@ -330,8 +330,8 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
 
     # Typically with a 2-legged access token
     @qod_provisioning_createProvisioning_422.5_unidentifiable_device
-    Scenario: Device not included and cannot be deducted from the access token
-        Given the header "Authorization" is set to a valid access which does not identifiy a single device
+    Scenario: Device not included and cannot be deduced from the access token
+        Given the header "Authorization" is set to a valid access token which does not identifiy a device
         And the request body property "$.device" is not included
         When the request "createProvisioning" is sent
         Then the response status code is 422

--- a/code/Test_definitions/qod-provisioning-createProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-createProvisioning.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation createProvisioning
+Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -234,19 +234,6 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation createProvisioning
 
     # Errors 403
 
-    @qod_provisioning_createProvisioning_403.1_device_token_mismatch
-    Scenario: Inconsistent access token context for the device
-        # To test this, a token have to be obtained for a different device
-        Given the request body property "$.device" is set to a valid testing device
-        And the header "Authorization" is set to a valid access token emitted for a different device
-        When the request "createProvisioning" is sent
-        Then the response status code is 403
-        And the response header "x-correlator" has same value as the request header "x-correlator"
-        And the response header "Content-Type" is "application/json"
-        And the response property "$.status" is 403
-        And the response property "$.code" is "INVALID_TOKEN_CONTEXT"
-        And the response property "$.message" contains a user friendly text
-
     # Errors 404
 
     # Typically with a 2-legged access token
@@ -259,7 +246,7 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation createProvisioning
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 404
-        And the response property "$.code" is "DEVICE_NOT_FOUND"
+        And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
         And the response property "$.message" contains a user friendly text
 
     # Errors 409
@@ -286,7 +273,7 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation createProvisioning
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "UNSUPPORTED_DEVICE_IDENTIFIERS"
+        And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
         And the response property "$.message" contains a user friendly text
 
     # This scenario is under discussion
@@ -299,7 +286,7 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation createProvisioning
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "DEVICE_IDENTIFIERS_MISMATCH"
+        And the response property "$.code" is "IDENTIFIER_MISMATCH"
         And the response property "$.message" contains a user friendly text
 
     @qod_provisioning_createProvisioning_422.3_device_not_supported
@@ -311,7 +298,7 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation createProvisioning
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "DEVICE_NOT_APPLICABLE"
+        And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
         And the response property "$.message" contains a user friendly text
 
     # TBD if we neeed a dedicated code
@@ -325,7 +312,7 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation createProvisioning
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "DEVICE_NOT_APPLICABLE"
+        And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
         And the response property "$.message" contains a user friendly text
 
     # Typically with a 2-legged access token
@@ -338,5 +325,32 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation createProvisioning
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "UNIDENTIFIABLE_DEVICE"
+        And the response property "$.code" is "MISSING_IDENTIFIER"
+        And the response property "$.message" contains a user friendly text
+
+    # Typically with a 3-legged access token
+    @qod_provisioning_createProvisioning_422.6_device_token_mismatch
+    Scenario: Inconsistent access token context for the device
+        # To test this, a token has to be obtained for a different device
+        Given the request body property "$.device" is set to a valid testing device
+        And the header "Authorization" is set to a valid access token obtained for a different device
+        When the request "createProvisioning" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
+        And the response property "$.message" contains a user friendly text
+
+    # Typically with a 3-legged access token
+    @qod_provisioning_createProvisioning_422.6_unnecessary explicit device identifier
+    Scenario: Explicit device identifier provided when device is identified by the access token
+        Given the request body property "$.device" is set to a valid testing device
+        And the header "Authorization" is set to a valid access token for that same device
+        When the request "createProvisioning" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
         And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/qod-provisioning-createProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-createProvisioning.feature
@@ -123,10 +123,12 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.code" is "INVALID_ARGUMENT"
         And the response property "$.message" contains a user friendly text
 
+    # Note that device schema validation errors (if any) should be thrown even if a 3-legged access token is being used
     @qod_provisioning_createProvisioning_400.5_device_identifiers_not_schema_compliant
     # Test every type of identifier even if not supported by the implementation
     Scenario Outline: Some device identifier value does not comply with the schema
         Given the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
+        And a 2-legged or 3-legged access token is being used
         When the request "createProvisioning" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -138,14 +140,14 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         Examples:
             | device_identifier          | oas_spec_schema                             |
             | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-            | $.device.ipv4Address       | /components/schemas/NetworkAccessIdentifier |
-            | $.device.ipv6Address       | /components/schemas/DeviceIpv4Addr          |
-            | $.device.networkIdentifier | /components/schemas/DeviceIpv6Address       |
+            | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
+            | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
+            | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
 
     # The maximum is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction, and both could be accepted
     @qod_provisioning_createProvisioning_400.6_out_of_range_port
     Scenario: Out of range port
-        Given the request body property  "$.device.ipv4Address.publicPort" is set to a value not between 0 and 65536
+        Given the request body property  "$.device.ipv4Address.publicPort" is set to a value not between 0 and 65535
         When the request "createProvisioning" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/qod-provisioning-createProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-createProvisioning.feature
@@ -237,7 +237,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
     # Errors 403
 
     @qod_provisioning_createProvisioning_403.1_missing_access_token_scope
-    Scenario: Invalid access token
+    Scenario: Missing access token scope
         Given the header "Authorization" is set to an access token that does not include scope qod-provisioning:device-qos:create
         When the request "createProvisioning" is sent
         Then the response status code is 403

--- a/code/Test_definitions/qod-provisioning-createProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-createProvisioning.feature
@@ -343,7 +343,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.message" contains a user friendly text
 
     # Typically with a 3-legged access token
-    @qod_provisioning_createProvisioning_422.6_unnecessary explicit device identifier
+    @qod_provisioning_createProvisioning_422.7_unnecessary_device_identifier_in_request
     Scenario: Explicit device identifier provided when device is identified by the access token
         Given the request body property "$.device" is set to a valid testing device
         And the header "Authorization" is set to a valid access token for that same device

--- a/code/Test_definitions/qod-provisioning-createProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-createProvisioning.feature
@@ -123,9 +123,9 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.code" is "INVALID_ARGUMENT"
         And the response property "$.message" contains a user friendly text
 
-    # Note that device schema validation errors (if any) should be thrown even if a 3-legged access token is being used
     @qod_provisioning_createProvisioning_400.5_device_identifiers_not_schema_compliant
     # Test every type of identifier even if not supported by the implementation
+    # Note that device schema validation errors (if any) should be thrown even if a 3-legged access token is being used
     Scenario Outline: Some device identifier value does not comply with the schema
         Given the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
         And a 2-legged or 3-legged access token is being used
@@ -147,7 +147,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
     # The maximum is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction, and both could be accepted
     @qod_provisioning_createProvisioning_400.6_out_of_range_port
     Scenario: Out of range port
-        Given the request body property  "$.device.ipv4Address.publicPort" is set to a value not between 0 and 65535
+        Given the request body property "$.device.ipv4Address.publicPort" is set to a value not between 0 and 65535
         When the request "createProvisioning" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/qod-provisioning-createProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-createProvisioning.feature
@@ -236,6 +236,17 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
 
     # Errors 403
 
+    @qod_provisioning_createProvisioning_403.1_missing_access_token_scope
+    Scenario: Invalid access token
+        Given the header "Authorization" is set to an access token that does not include scope qod-provisioning:device-qos:create
+        When the request "createProvisioning" is sent
+        Then the response status code is 403
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 403
+        And the response property "$.code" is "PERMISSION_DENIED"
+        And the response property "$.message" contains a user friendly text  
+    
     # Errors 404
 
     # Typically with a 2-legged access token
@@ -281,7 +292,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
     # This scenario is under discussion
     @qod_provisioning_createProvisioning_422.2_device_identifiers_mismatch
     Scenario: Device identifiers mismatch
-        Given that al least 2 types of device identifiers are supported by the implementation
+        Given that at least 2 types of device identifiers are supported by the implementation
         And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
         When the request "createProvisioning" is sent
         Then the response status code is 422

--- a/code/Test_definitions/qod-provisioning-createProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-createProvisioning.feature
@@ -14,7 +14,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
 
     Background: Common createProvisioning setup
         Given an environment at "apiRoot"
-        And the resource "/qod-provisioning/v0.1/device-qos"                                                              |
+        And the resource "/qod-provisioning/vwip/device-qos"                                                              |
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" is set to a UUID value

--- a/code/Test_definitions/qod-provisioning-createProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-createProvisioning.feature
@@ -10,7 +10,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
     # * A device object applicable for QoD provisioning service
     # * A device object identifying a device commercialized by the implementation for which the service is not applicable, if any
     #
-    # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml, version 0.1.0
+    # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml, version wip
 
     Background: Common createProvisioning setup
         Given an environment at "apiRoot"

--- a/code/Test_definitions/qod-provisioning-deleteProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-deleteProvisioning.feature
@@ -8,7 +8,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
     # * The ProvisioningInfo of an existing QoD Provisiong
     # * The ProvisioningInfo of an existing QoD Provisiong with status "AVAILABLE", and with provided values for "sink" and "sinkCredential"
     #
-    # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml, version 0.1.0
+    # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml, version wip
 
     Background: Common deleteProvisioning setup
         Given an environment at "apiRoot"

--- a/code/Test_definitions/qod-provisioning-deleteProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-deleteProvisioning.feature
@@ -12,7 +12,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
 
     Background: Common deleteProvisioning setup
         Given an environment at "apiRoot"
-        And the resource "/qod-provisioning/v0.1/device-qos/{provisioningId}"
+        And the resource "/qod-provisioning/vwip/device-qos/{provisioningId}"
         # Unless indicated otherwise the QoD provisioning must be created by the same API client given in the access token
         And the header "Authorization" is set to a valid access token granted to the same client that created the QoD provisoning
         And the header "x-correlator" is set to a UUID value

--- a/code/Test_definitions/qod-provisioning-deleteProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-deleteProvisioning.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation deleteProvisioning
+Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:

--- a/code/Test_definitions/qod-provisioning-deleteProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-deleteProvisioning.feature
@@ -149,7 +149,7 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation deleteProvisioning
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 403
-        And the response property "$.code" is "PERMISSION_DENIED" or "INVALID_TOKEN_CONTEXT"
+        And the response property "$.code" is "PERMISSION_DENIED"
         And the response property "$.message" contains a user friendly text
 
     # Errors 404

--- a/code/Test_definitions/qod-provisioning-deleteProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-deleteProvisioning.feature
@@ -139,8 +139,18 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
 
     # Errors 403
 
-    # TBD which code is more appropriate for this scenario
-    @qod_provisioning_deleteProvisioning_403.1_different_client_id
+    @qod_provisioning_deleteProvisioning_403.1_missing_access_token_scope
+    Scenario: Missing access token scope
+        Given the header "Authorization" is set to an access token that does not include scope qod-provisioning:device-qos:delete
+        When the request "deleteProvisioning" is sent
+        Then the response status code is 403
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 403
+        And the response property "$.code" is "PERMISSION_DENIED"
+        And the response property "$.message" contains a user friendly text
+
+    @qod_provisioning_deleteProvisioning_403.2_different_client_id
     Scenario: QoD provisioning not created by the API client given in the access token
         # To test this, a token have to be obtained by a different client
         Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoD provisioning

--- a/code/Test_definitions/qod-provisioning-getProvisioningById.feature
+++ b/code/Test_definitions/qod-provisioning-getProvisioningById.feature
@@ -101,8 +101,18 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
 
     # Errors 403
 
-    # TBD which code is more appropriate for this scenario
-    @qod_provisioning_getProvisioningById_403.1_different_client_id
+    @qod_provisioning_getProvisioningById_403.1_missing_access_token_scope
+    Scenario: Missing access token scope
+        Given the header "Authorization" is set to an access token that does not include scope qod-provisioning:device-qos:read
+        When the request "getProvisioningById" is sent
+        Then the response status code is 403
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 403
+        And the response property "$.code" is "PERMISSION_DENIED"
+        And the response property "$.message" contains a user friendly text
+
+    @qod_provisioning_getProvisioningById_403.2_different_client_id
     Scenario: QoD provisioning not created by the API client given in the access token
         # To test this, a token have to be obtained by a different client
         Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoD provisioning

--- a/code/Test_definitions/qod-provisioning-getProvisioningById.feature
+++ b/code/Test_definitions/qod-provisioning-getProvisioningById.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation getProvisioningById
+Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:

--- a/code/Test_definitions/qod-provisioning-getProvisioningById.feature
+++ b/code/Test_definitions/qod-provisioning-getProvisioningById.feature
@@ -111,7 +111,7 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation getProvisioningById
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 403
-        And the response property "$.code" is "PERMISSION_DENIED" or "INVALID_TOKEN_CONTEXT"
+        And the response property "$.code" is "PERMISSION_DENIED"
         And the response property "$.message" contains a user friendly text
 
     # Errors 404

--- a/code/Test_definitions/qod-provisioning-getProvisioningById.feature
+++ b/code/Test_definitions/qod-provisioning-getProvisioningById.feature
@@ -7,11 +7,11 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
     # Testing assets:
     # * The provisioningId of an existing QoD Provisiong, and the request properties used for createProvisioning
     #
-    # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml, version 0.1.0
+    # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml, version wip
 
     Background: Common getProvisioningById setup
         Given an environment at "apiRoot"
-        And the resource "/qod-provisioning/v0.1/device-qos/{provisioningId}"                                                              |
+        And the resource "/qod-provisioning/vwip/device-qos/{provisioningId}"                                                              |
         # Unless indicated otherwise the QoD provisioning must be created by the same API client given in the access token
         And the header "Authorization" is set to a valid access token granted to the same client that created the QoD provisoning
         And the header "x-correlator" is set to a UUID value

--- a/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
+++ b/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation retrieveProvisioningByDevice
+Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDevice
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:

--- a/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
+++ b/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
@@ -155,8 +155,18 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
 
     # Errors 403
 
-    # TBD which code is more appropriate for this scenario
-    @qod_provisioning_retrieveProvisioningByDevice_403.1_different_client_id
+    @qod_provisioning_retrieveProvisioningByDevice_403.1_missing_access_token_scope
+    Scenario: Missing access token scope
+        Given the header "Authorization" is set to an access token that does not include scope qod-provisioning:device-qos:read-by-device
+        When the request "retrieveProvisioningByDevice" is sent
+        Then the response status code is 403
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 403
+        And the response property "$.code" is "PERMISSION_DENIED"
+        And the response property "$.message" contains a user friendly text
+
+    @qod_provisioning_retrieveProvisioningByDevice_403.2_different_client_id
     Scenario: QoD provisioning not created by the API client given in the access token
         # To test this, a token have to be obtained for a different client
         Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoD provisioning

--- a/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
+++ b/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
@@ -165,20 +165,7 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation retrieveProvisioningByD
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 403
-        And the response property "$.code" is "PERMISSION_DENIED" or "INVALID_TOKEN_CONTEXT"
-        And the response property "$.message" contains a user friendly text
-
-    @qod_provisioning_retrieveProvisioningByDevice_403.2_device_token_mismatch
-    Scenario: Inconsistent access token context for the device
-        # To test this, a token have to be obtained for a different device
-        Given the request body property "$.device" is set to a valid testing device
-        And the header "Authorization" is set to a valid access token emitted for a different device
-        When the request "retrieveProvisioningByDevice" is sent
-        Then the response status code is 403
-        And the response header "x-correlator" has same value as the request header "x-correlator"
-        And the response header "Content-Type" is "application/json"
-        And the response property "$.status" is 403
-        And the response property "$.code" is "INVALID_TOKEN_CONTEXT"
+        And the response property "$.code" is "PERMISSION_DENIED"
         And the response property "$.message" contains a user friendly text
 
     # Errors 404
@@ -204,7 +191,7 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation retrieveProvisioningByD
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 404
-        And the response property "$.code" is "DEVICE_NOT_FOUND"
+        And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
         And the response property "$.message" contains a user friendly text
 
     # Errors 422
@@ -218,7 +205,7 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation retrieveProvisioningByD
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "UNSUPPORTED_DEVICE_IDENTIFIERS"
+        And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
         And the response property "$.message" contains a user friendly text
 
     # This scenario is under discussion
@@ -231,7 +218,7 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation retrieveProvisioningByD
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "DEVICE_IDENTIFIERS_MISMATCH"
+        And the response property "$.code" is "IDENTIFIER_MISMATCH"
         And the response property "$.message" contains a user friendly text
 
     @qod_provisioning_retrieveProvisioningByDevice_422.3_device_not_supported
@@ -243,7 +230,7 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation retrieveProvisioningByD
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "DEVICE_NOT_APPLICABLE"
+        And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
         And the response property "$.message" contains a user friendly text
 
     # Typically with a 2-legged access token
@@ -256,5 +243,32 @@ Feature: CAMARA QoD Provisioning API, v0.1.1 - Operation retrieveProvisioningByD
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "UNIDENTIFIABLE_DEVICE"
+        And the response property "$.code" is "MISSING_IDENTIFIER"
         And the response property "$.message" contains a user friendly text
+
+    # Typically with a 3-legged access token
+    @qod_provisioning_createProvisioning_422.6_device_token_mismatch
+    Scenario: Inconsistent access token context for the device
+        # To test this, a token has to be obtained for a different device
+        Given the request body property "$.device" is set to a valid testing device
+        And the header "Authorization" is set to a valid access token obtained for a different device
+        When the request "createProvisioning" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
+        And the response property "$.message" contains a user friendly text
+
+    # Typically with a 3-legged access token
+    @qod_provisioning_createProvisioning_422.7_unnecessary_device_identifier_in_request
+    Scenario: Explicit device identifier provided when device is identified by the access token
+        Given the request body property "$.device" is set to a valid testing device
+        And the header "Authorization" is set to a valid access token for that same device
+        When the request "createProvisioning" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
+        And the response property "$.message" contains a user friendly text        

--- a/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
+++ b/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
@@ -11,11 +11,11 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
     # * A device object with NO existing QoD provisioning associated
     # * A device object identifying a device commercialized by the implementation for which the service is not applicable, if any
     #
-    # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml, version 0.1.0
+    # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml, version wip
 
     Background: Common retrieveProvisioningByDevice setup
         Given an environment at "apiRoot"
-        And the resource "/qod-provisioning/v0.1/retrieve-device-qos"                                                              |
+        And the resource "/qod-provisioning/vwip/retrieve-device-qos"                                                              |
         And the header "Content-Type" is set to "application/json"
         # Unless indicated otherwise the QoD provisioning must be created by the same API client given in the access token
         And the header "Authorization" is set to a valid access token granted to the same client that created the QoD provisoning

--- a/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
+++ b/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
@@ -246,7 +246,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
     # Typically with a 2-legged access token
     @qod_provisioning_retrieveProvisioningByDevice_422.4_unidentifiable_device
     Scenario: Device not included and cannot be deduced from the access token
-        Given the header "Authorization" is set to a valid access token which does not identifiy a device
+        Given the header "Authorization" is set to a valid access token which does not identify a device
         And the request body property "$.device" is not included
         When the request "retrieveProvisioningByDevice" is sent
         Then the response status code is 422

--- a/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
+++ b/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
@@ -245,8 +245,8 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
 
     # Typically with a 2-legged access token
     @qod_provisioning_retrieveProvisioningByDevice_422.4_unidentifiable_device
-    Scenario: Device not included and cannot be deducted from the access token
-        Given the header "Authorization" is set to a valid access which does not identifiy a single device
+    Scenario: Device not included and cannot be deduced from the access token
+        Given the header "Authorization" is set to a valid access token which does not identifiy a device
         And the request body property "$.device" is not included
         When the request "retrieveProvisioningByDevice" is sent
         Then the response status code is 422

--- a/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
+++ b/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
@@ -247,12 +247,12 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response property "$.message" contains a user friendly text
 
     # Typically with a 3-legged access token
-    @qod_provisioning_createProvisioning_422.6_device_token_mismatch
+    @qod_provisioning_retrieveProvisioningByDevice_422.5_device_token_mismatch
     Scenario: Inconsistent access token context for the device
         # To test this, a token has to be obtained for a different device
         Given the request body property "$.device" is set to a valid testing device
         And the header "Authorization" is set to a valid access token obtained for a different device
-        When the request "createProvisioning" is sent
+        When the request "retrieveProvisioningByDevice" is sent
         Then the response status code is 422
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -261,11 +261,11 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response property "$.message" contains a user friendly text
 
     # Typically with a 3-legged access token
-    @qod_provisioning_createProvisioning_422.7_unnecessary_device_identifier_in_request
+    @qod_provisioning_retrieveProvisioningByDevice_422.6_unnecessary_device_identifier_in_request
     Scenario: Explicit device identifier provided when device is identified by the access token
         Given the request body property "$.device" is set to a valid testing device
         And the header "Authorization" is set to a valid access token for that same device
-        When the request "createProvisioning" is sent
+        When the request "retrieveProvisioningByDevice" is sent
         Then the response status code is 422
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/qos-profiles-getQosProfile.feature
+++ b/code/Test_definitions/qos-profiles-getQosProfile.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoS Profiles API, v0.11.1 - Operation getQosProfile
+Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -7,7 +7,7 @@ Feature: CAMARA QoS Profiles API, v0.11.1 - Operation getQosProfile
     # Testing assets:
     # * The name of an existing QoS profile
     #
-    # References to OAS spec schemas refer to schemas specifies in qos-profiles.yaml, version 0.11.0
+    # References to OAS spec schemas refer to schemas specifies in qos-profiles.yaml, version wip
 
     Background: Common getQosProfile setup
         Given an environment at "apiRoot"

--- a/code/Test_definitions/qos-profiles-getQosProfile.feature
+++ b/code/Test_definitions/qos-profiles-getQosProfile.feature
@@ -11,7 +11,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
 
     Background: Common getQosProfile setup
         Given an environment at "apiRoot"
-        And the resource "qos-profiles/v0.11/qos-profiles/{name}"
+        And the resource "qos-profiles/vwip/qos-profiles/{name}"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" is set to a UUID value
         And the path param "name" is set by default to a existing QoS profile name

--- a/code/Test_definitions/qos-profiles-getQosProfile.feature
+++ b/code/Test_definitions/qos-profiles-getQosProfile.feature
@@ -94,7 +94,20 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
         And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
-    # Errors 404
+    # Generic 403 errors
+
+    @qos_profiles_getQosProfile_403.1_missing_access_token_scope
+    Scenario: Missing access token scope
+        Given the header "Authorization" is set to an access token that does not include scope qos-profiles:read
+        When the request "getQosProfile" is sent
+        Then the response status code is 403
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 403
+        And the response property "$.code" is "PERMISSION_DENIED"
+        And the response property "$.message" contains a user friendly text
+
+    # Generic 404 errors
 
     @qos_profiles_getQosProfile_404.1_not_found
     Scenario: name of a no existing QoS profile

--- a/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
@@ -15,7 +15,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
 
     Background: Common retrieveQoSProfiles setup
         Given an environment at "apiRoot"
-        And the resource "qos-profiles/v0.11/retrieve-qos-profiles"
+        And the resource "qos-profiles/vwip/retrieve-qos-profiles"
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" is set to a UUID value

--- a/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoS Profiles API, v0.11.1 - Operation retrieveQoSProfiles
+Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -11,7 +11,7 @@ Feature: CAMARA QoS Profiles API, v0.11.1 - Operation retrieveQoSProfiles
     # * If some QoS Profile is restricted for some devices, provide the QoS profile name and device
     # * A device object identifying a device commercialized by the implementation for which the service is not applicable, if any
 
-    # References to OAS spec schemas refer to schemas specifies in qos-profiles.yaml, version 0.11.0
+    # References to OAS spec schemas refer to schemas specifies in qos-profiles.yaml, version wip
 
     Background: Common retrieveQoSProfiles setup
         Given an environment at "apiRoot"
@@ -179,22 +179,8 @@ Feature: CAMARA QoS Profiles API, v0.11.1 - Operation retrieveQoSProfiles
 
     # Errors 403
 
-    @qos_profiles_retrieveQoSProfiles_403.1_device_token_mismatch
-    Scenario: Inconsistent access token context for the device
-        # To test this, a token have to be obtained for a different device
-        Given the request body property "$.device" is set to a valid testing device
-        And the header "Authorization" is set to a valid access token emitted for a different device
-        When the request "retrieveQoSProfiles" is sent
-        Then the response status code is 403
-        And the response header "x-correlator" has same value as the request header "x-correlator"
-        And the response header "Content-Type" is "application/json"
-        And the response property "$.status" is 403
-        And the response property "$.code" is "INVALID_TOKEN_CONTEXT"
-        And the response property "$.message" contains a user friendly text
-
     # Errors 422
 
-    # UNSUPPORTED_DEVICE_IDENTIFIERS is in the Commonalities guidelines (document) but it is not yet considered in the API spec
     @qos_profiles_retrieveQoSProfiles_422.1_device_identifiers_unsupported
     Scenario: None of the provided device identifiers is supported by the implementation
         Given that some type of device identifiers are not supported by the implementation
@@ -204,7 +190,7 @@ Feature: CAMARA QoS Profiles API, v0.11.1 - Operation retrieveQoSProfiles
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "UNPROCESSABLE_ENTITY"
+        And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
         And the response property "$.message" contains a user friendly text
 
     # This scenario is under discussion
@@ -217,5 +203,45 @@ Feature: CAMARA QoS Profiles API, v0.11.1 - Operation retrieveQoSProfiles
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "DEVICE_IDENTIFIERS_MISMATCH"
+        And the response property "$.code" is "IDENTIFIER_MISMATCH"
+        And the response property "$.message" contains a user friendly text
+
+    # Typically with a 2-legged access token
+    @qod_provisioning_retrieveQoSProfiles_422.3_unidentifiable_device
+    Scenario: Device not included and cannot be deducted from the access token
+        Given the header "Authorization" is set to a valid access token that does not identifiy a valid testing device
+        And the request body property "$.device" is not included
+        When the request "retrieveQoSProfiles" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "MISSING_IDENTIFIER"
+        And the response property "$.message" contains a user friendly text
+
+    # Typically with a 3-legged access token
+    @qod_provisioning_retrieveQoSProfiles_422.4_device_token_mismatch
+    Scenario: Inconsistent access token context for the device
+        # To test this, a token has to be obtained for a different device
+        Given the request body property "$.device" is set to a valid testing device
+        And the header "Authorization" is set to a valid access token obtained for a different device
+        When the request "retrieveQoSProfiles" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
+        And the response property "$.message" contains a user friendly text
+
+    # Typically with a 3-legged access token
+    @qod_provisioning_retrieveQoSProfiles_422.5_unnecessary_device_identifier_in_request
+    Scenario: Explicit device identifier provided when device is identified by the access token
+        Given the request body property "$.device" is set to a valid testing device
+        And the header "Authorization" is set to a valid access token for that same device
+        When the request "retrieveQoSProfiles" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
         And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
@@ -219,8 +219,8 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
 
     # Typically with a 2-legged access token
     @qod_provisioning_retrieveQoSProfiles_422.3_unidentifiable_device
-    Scenario: Device not included and cannot be deducted from the access token
-        Given the header "Authorization" is set to a valid access token that does not identifiy a valid testing device
+    Scenario: Device not included and cannot be deduced from the access token
+        Given the header "Authorization" is set to a valid access token that does not identify a device
         And the request body property "$.device" is not included
         When the request "retrieveQoSProfiles" is sent
         Then the response status code is 422

--- a/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
@@ -134,9 +134,9 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
         Examples:
             | device_identifier          | oas_spec_schema                             |
             | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-            | $.device.ipv4Address       | /components/schemas/NetworkAccessIdentifier |
-            | $.device.ipv6Address       | /components/schemas/DeviceIpv4Addr          |
-            | $.device.networkIdentifier | /components/schemas/DeviceIpv6Address       |
+            | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
+            | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
+            | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
 
     # Generic 401 errors
 
@@ -177,9 +177,20 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
         And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
-    # Errors 403
+    # Generic 403 errors
 
-    # Errors 422
+    @qos_profiles_retrieveQoSProfiles_403.1_missing_access_token_scope
+    Scenario: Missing access token scope
+        Given the header "Authorization" is set to an access token that does not include scope qos-profiles:read
+        When the request "retrieveQoSProfiles" is sent
+        Then the response status code is 403
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 403
+        And the response property "$.code" is "PERMISSION_DENIED"
+        And the response property "$.message" contains a user friendly text
+
+    # Generic 422 errors
 
     @qos_profiles_retrieveQoSProfiles_422.1_device_identifiers_unsupported
     Scenario: None of the provided device identifiers is supported by the implementation

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -277,6 +277,17 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
 
     # Errors 403
 
+    @quality_on_demand_createSession_403.1_missing_access_token_scope
+    Scenario: Missing access token scope
+        Given the header "Authorization" is set to an access token that does not include scope quality-on-demand:sessions:create
+        When the request "createSession" is sent
+        Then the response status code is 403
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 403
+        And the response property "$.code" is "PERMISSION_DENIED"
+        And the response property "$.message" contains a user friendly text
+
     # Errors 404
 
     # Typically with a 2-legged access token

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -275,19 +275,6 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
 
     # Errors 403
 
-    @quality_on_demand_createSession_403.1_device_token_mismatch
-    Scenario: Inconsistent access token context for the device
-        # To test this, a token have to be obtained for a different device
-        Given the request body property "$.device" is set to a valid testing device
-        And the header "Authorization" is set to a valid access token emitted for a different device
-        When the request "createSession" is sent
-        Then the response status code is 403
-        And the response header "x-correlator" has same value as the request header "x-correlator"
-        And the response header "Content-Type" is "application/json"
-        And the response property "$.status" is 403
-        And the response property "$.code" is "INVALID_TOKEN_CONTEXT"
-        And the response property "$.message" contains a user friendly text
-
     # Errors 404
 
     # Typically with a 2-legged access token

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -142,8 +142,10 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
 
     @quality_on_demand_createSession_400.5_device_identifiers_not_schema_compliant
     # Test every type of identifier even if not supported by the implementation
+    # Note that device schema validation errors (if any) should be thrown even if a 3-legged access token is being used
     Scenario Outline: Some device identifier value does not comply with the schema
         Given the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
+        And a 2-legged or 3-legged access token is being used
         When the request "createSession" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -155,15 +157,15 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
         Examples:
             | device_identifier          | oas_spec_schema                             |
             | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-            | $.device.ipv4Address       | /components/schemas/NetworkAccessIdentifier |
-            | $.device.ipv6Address       | /components/schemas/DeviceIpv4Addr          |
-            | $.device.networkIdentifier | /components/schemas/DeviceIpv6Address       |
+            | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
+            | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
+            | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
 
     # The maximum is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction,
     # and both could be accepted
     @quality_on_demand_createSession_400.6_out_of_range_port
     Scenario Outline: Out of range port
-        Given the request body property "<port_property>" is set to a value not between between 0 and 65536
+        Given the request body property "<port_property>" is set to a value not between between 0 and 65535
         When the request "createSession" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Quality On Demand API, v0.11.1 - Operation createSession
+Feature: CAMARA Quality On Demand API, vwip - Operation createSession
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -11,11 +11,11 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation createSession
     # * A device object applicable for Quality On Demand service.
     # * A device object identifying a device commercialized by the implementation for which the service is not applicable, if any.
     #
-    # References to OAS spec schemas refer to schemas specifies in quality-on-demand.yaml, version 0.11.0
+    # References to OAS spec schemas refer to schemas specifies in quality-on-demand.yaml, version wip
 
     Background: Common createSession setup
         Given an environment at "apiRoot"
-        And the resource "/quality-on-demand/v0.11/sessions"
+        And the resource "/quality-on-demand/vwip/sessions"
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" is set to a UUID value
@@ -300,7 +300,7 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation createSession
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 404
-        And the response property "$.code" is "DEVICE_NOT_FOUND"
+        And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
         And the response property "$.message" contains a user friendly text
 
     # Errors 409
@@ -319,7 +319,6 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation createSession
 
     # Errors 422
 
-    # UNSUPPORTED_DEVICE_IDENTIFIERS is in the Commonalities guidelines (document) but it is not yet considered in the API spec
     @quality_on_demand_createSession_422.1_device_identifiers_unsupported
     Scenario: None of the provided device identifiers is supported by the implementation
         Given that some type of device identifiers are not supported by the implementation
@@ -329,7 +328,7 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation createSession
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "UNSUPPORTED_DEVICE_IDENTIFIERS"
+        And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
         And the response property "$.message" contains a user friendly text
 
     # This scenario is under discussion
@@ -342,7 +341,7 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation createSession
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "DEVICE_IDENTIFIERS_MISMATCH"
+        And the response property "$.code" is "IDENTIFIER_MISMATCH"
         And the response property "$.message" contains a user friendly text
 
     @quality_on_demand_createSession_422.3_device_not_supported
@@ -354,11 +353,25 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation createSession
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "DEVICE_NOT_APPLICABLE"
+        And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
+        And the response property "$.message" contains a user friendly text
+
+    # TBD if we neeed a dedicated code
+    @quality_on_demand_createSession_422.4_qos_profile_incompatible_device
+    Scenario: QoS profile is not suitable for the device
+        Given that implementation has QoS Profiles restricted to certain devices
+        And the request body property "qosProfile" is set to a restricted QoS Profile
+        And a device not suitable for the restricted QoS Profiles is provided in the request body or identified by the access token
+        When the request "createSession" is sent
+        Then the response status code is 400
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
         And the response property "$.message" contains a user friendly text
 
     # Typically with a 2-legged access token
-    @quality_on_demand_createSession_422.4_unidentifiable_device
+    @quality_on_demand_createSession_422.5_unidentifiable_device
     Scenario: Device not included and cannot be deducted from the access token
         Given the header "Authorization" is set to a valid access which does not identifiy a single device
         And the request body property "$.device" is not included
@@ -367,5 +380,32 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation createSession
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "UNIDENTIFIABLE_DEVICE"
+        And the response property "$.code" is "MISSING_IDENTIFIER"
+        And the response property "$.message" contains a user friendly text
+
+    # Typically with a 3-legged access token
+    @quality_on_demand_createSession_422.6_device_token_mismatch
+    Scenario: Inconsistent access token context for the device
+        # To test this, a token has to be obtained for a different device
+        Given the request body property "$.device" is set to a valid testing device
+        And the header "Authorization" is set to a valid access token obtained for a different device
+        When the request "createSession" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
+        And the response property "$.message" contains a user friendly text
+
+    # Typically with a 3-legged access token
+    @quality_on_demand_createSession_422.7_unnecessary_device_identifier_in_request
+    Scenario: Explicit device identifier provided when device is identified by the access token
+        Given the request body property "$.device" is set to a valid testing device
+        And the header "Authorization" is set to a valid access token for that same device
+        When the request "createSession" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
         And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -373,7 +373,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
     # Typically with a 2-legged access token
     @quality_on_demand_createSession_422.5_unidentifiable_device
     Scenario: Device not included and cannot be deduced from the access token
-        Given the header "Authorization" is set to a valid access token which does not identifiy a device
+        Given the header "Authorization" is set to a valid access token which does not identify a device
         And the request body property "$.device" is not included
         When the request "createSession" is sent
         Then the response status code is 422

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -372,8 +372,8 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
 
     # Typically with a 2-legged access token
     @quality_on_demand_createSession_422.5_unidentifiable_device
-    Scenario: Device not included and cannot be deducted from the access token
-        Given the header "Authorization" is set to a valid access which does not identifiy a single device
+    Scenario: Device not included and cannot be deduced from the access token
+        Given the header "Authorization" is set to a valid access token which does not identifiy a device
         And the request body property "$.device" is not included
         When the request "createSession" is sent
         Then the response status code is 422

--- a/code/Test_definitions/quality-on-demand-deleteSession.feature
+++ b/code/Test_definitions/quality-on-demand-deleteSession.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Quality On Demand API, v0.11.1 - Operation deleteSession
+Feature: CAMARA Quality On Demand API, vwip - Operation deleteSession
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -9,7 +9,7 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation deleteSession
     # * The sessionId of an existing session with status "AVAILABLE", and with provided values for "sink" and "sinkCredential".
     # * The sessionId of an existing session with status "UNAVAILABLE", and with provided values for "sink" and "sinkCredential".
     #
-    # References to OAS spec schemas refer to schemas specifies in quality-on-demand.yaml, version 0.11.0
+    # References to OAS spec schemas refer to schemas specifies in quality-on-demand.yaml, version wip
 
     Background: Common deleteSession setup
         Given an environment at "apiRoot"
@@ -109,7 +109,7 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation deleteSession
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 403
-        And the response property "$.code" is "PERMISSION_DENIED" or "INVALID_TOKEN_CONTEXT"
+        And the response property "$.code" is "PERMISSION_DENIED"
         And the response property "$.message" contains a user friendly text
 
     # Errors 404

--- a/code/Test_definitions/quality-on-demand-deleteSession.feature
+++ b/code/Test_definitions/quality-on-demand-deleteSession.feature
@@ -97,10 +97,20 @@ Feature: CAMARA Quality On Demand API, vwip - Operation deleteSession
         And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
-    # Errors 403
+    # Generic 403 errors
 
-    # TBD which code is more appropriate for this scenario
-    @quality_on_demand_deleteSession_403.1_session_token_mismatch
+    @quality_on_demand_deleteSession_403.1_missing_access_token_scope
+    Scenario: Missing access token scope
+        Given the header "Authorization" is set to an access token that does not include scope quality-on-demand:sessions:delete
+        When the request "deleteSession" is sent
+        Then the response status code is 403
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 403
+        And the response property "$.code" is "PERMISSION_DENIED"
+        And the response property "$.message" contains a user friendly text
+
+    @quality_on_demand_deleteSession_403.2_session_token_mismatch
     Scenario: QoS session not created by the API client given in the access token
         # To test this, a token have to be obtained for a different client
         Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoS session

--- a/code/Test_definitions/quality-on-demand-extendQosSessionDuration.feature
+++ b/code/Test_definitions/quality-on-demand-extendQosSessionDuration.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Quality On Demand API, v0.11.1 - Operation extendQosSessionDuration
+Feature: CAMARA Quality On Demand API, vwip - Operation extendQosSessionDuration
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -8,11 +8,11 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation extendQosSessionDurat
     # * The sessionId of an existing session with qosStatus "AVAILABLE"
     # * The sessionId of an existing session with qosStatus "UNAVAILABLE"
     #
-    # References to OAS spec schemas refer to schemas specifies in quality-on-demand.yaml, version 0.11.0
+    # References to OAS spec schemas refer to schemas specifies in quality-on-demand.yaml, version wip
 
     Background: Common extendQosSessionDuration setup
         Given an environment at "apiRoot"
-        And the resource "/quality-on-demand/v0.11/sessions/{sessionId}/extend"
+        And the resource "/quality-on-demand/vwip/sessions/{sessionId}/extend"
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" is set to a UUID value
@@ -154,7 +154,7 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation extendQosSessionDurat
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 403
-        And the response property "$.code" is "PERMISSION_DENIED" or "INVALID_TOKEN_CONTEXT"
+        And the response property "$.code" is "PERMISSION_DENIED"
         And the response property "$.message" contains a user friendly text
 
     # Errors 404

--- a/code/Test_definitions/quality-on-demand-extendQosSessionDuration.feature
+++ b/code/Test_definitions/quality-on-demand-extendQosSessionDuration.feature
@@ -142,10 +142,20 @@ Feature: CAMARA Quality On Demand API, vwip - Operation extendQosSessionDuration
         And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
-    # Errors 403
+    # Generic 403 errors
 
-    # TBD which code is more appropriate for this scenario
-    @quality_on_demand_extendQosSessionDuration_403.1_session_token_mismatch
+    @quality_on_demand_extendQosSessionDuration_403.1_missing_access_token_scope
+    Scenario: Missing access token scope
+        Given the header "Authorization" is set to an access token that does not include scope quality-on-demand:sessions:update
+        When the request "extendQosSessionDuration" is sent
+        Then the response status code is 403
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 403
+        And the response property "$.code" is "PERMISSION_DENIED"
+        And the response property "$.message" contains a user friendly text
+
+    @quality_on_demand_extendQosSessionDuration_403.2_session_token_mismatch
     Scenario: QoS session not created by the API client given in the access token
         # To test this, a token have to be obtained for a different client
         Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoS session

--- a/code/Test_definitions/quality-on-demand-getSession.feature
+++ b/code/Test_definitions/quality-on-demand-getSession.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Quality On Demand API, v0.11.1 - Operation getSession
+Feature: CAMARA Quality On Demand API, vwip - Operation getSession
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -7,11 +7,11 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation getSession
     # Testing assets:
     # * The sessionId of an existing QoS session, and the request properties used for createSession
     #
-    # References to OAS spec schemas refer to schemas specifies in quality-on-demand.yaml, version 0.11.0
+    # References to OAS spec schemas refer to schemas specifies in quality-on-demand.yaml, version wip
 
     Background: Common getSession setup
         Given an environment at "apiRoot"
-        And the resource "/quality-on-demand/v0.11/sessions/{sessionId}"
+        And the resource "/quality-on-demand/vwip/sessions/{sessionId}"
         # Unless indicated otherwise the session must be created by the same API client given in the access token
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" is set to a UUID value
@@ -115,7 +115,7 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation getSession
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 403
-        And the response property "$.code" is "PERMISSION_DENIED" or "INVALID_TOKEN_CONTEXT"
+        And the response property "$.code" is "PERMISSION_DENIED"
         And the response property "$.message" contains a user friendly text
 
     # Errors 404

--- a/code/Test_definitions/quality-on-demand-getSession.feature
+++ b/code/Test_definitions/quality-on-demand-getSession.feature
@@ -105,8 +105,18 @@ Feature: CAMARA Quality On Demand API, vwip - Operation getSession
 
     # Errors 403
 
-    # TBD which code is more appropriate for this scenario
-    @quality_on_demand_getSession_403.1_session_token_mismatch
+    @quality_on_demand_getSession_403.1_missing_access_token_scope
+    Scenario: Missing access token scope
+        Given the header "Authorization" is set to an access token that does not include scope quality-on-demand:sessions:read
+        When the request "getSession" is sent
+        Then the response status code is 403
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 403
+        And the response property "$.code" is "PERMISSION_DENIED"
+        And the response property "$.message" contains a user friendly text
+
+    @quality_on_demand_getSession_403.2_session_token_mismatch
     Scenario: QoS session not created by the API client given in the access token
         # To test this, a token have to be obtained for a different client
         Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoS session

--- a/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
+++ b/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
@@ -116,9 +116,9 @@ Feature: CAMARA Quality On Demand API, vwip - Operation retrieveSessionsByDevice
         Examples:
             | device_identifier          | oas_spec_schema                             |
             | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-            | $.device.ipv4Address       | /components/schemas/NetworkAccessIdentifier |
-            | $.device.ipv6Address       | /components/schemas/DeviceIpv4Addr          |
-            | $.device.networkIdentifier | /components/schemas/DeviceIpv6Address       |
+            | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
+            | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
+            | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
 
     # The maximum is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction,
     # and both could be accepted
@@ -173,6 +173,17 @@ Feature: CAMARA Quality On Demand API, vwip - Operation retrieveSessionsByDevice
         And the response property "$.message" contains a user friendly text
 
     # Errors 403
+
+    @quality_on_demand_retrieveSessionsByDevice_403.1_missing_access_token_scope
+    Scenario: Missing access token scope
+        Given the header "Authorization" is set to an access token that does not include scope qod-provisioning:device-qos:retrieve-by-device
+        When the request "retrieveSessionsByDevice" is sent
+        Then the response status code is 403
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 403
+        And the response property "$.code" is "PERMISSION_DENIED"
+        And the response property "$.message" contains a user friendly text
 
     # Errors 404
 

--- a/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
+++ b/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
@@ -241,8 +241,8 @@ Feature: CAMARA Quality On Demand API, vwip - Operation retrieveSessionsByDevice
 
     # Typically with a 2-legged access token
     @quality_on_demand_retrieveSessionsByDevice_422.4_unidentifiable_device
-    Scenario: Device not included and cannot be deducted from the access token
-        Given the header "Authorization" is set to a valid access which does not identifiy a single device
+    Scenario: Device not included and cannot be deduced from the access token
+        Given the header "Authorization" is set to a valid access token which does not identify a device
         And the request body property "$.device" is not included
         When the request "retrieveSessionsByDevice" is sent
         Then the response status code is 422

--- a/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
+++ b/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Quality On Demand API, v0.11.1 - Operation retrieveSessionsByDevice
+Feature: CAMARA Quality On Demand API, vwip - Operation retrieveSessionsByDevice
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -11,11 +11,11 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation retrieveSessionsByDev
     # * A device object applicable for Quality On Demand service with NO QoS Sessions associated
     # * A device object identifying a device commercialized by the implementation for which the service is not applicable, if any.
     #
-    # References to OAS spec schemas refer to schemas specifies in quality-on-demand.yaml, version 0.11.0
+    # References to OAS spec schemas refer to schemas specifies in quality-on-demand.yaml, version wip
 
     Background: Common retrieveSessionsByDevice setup
         Given an environment at "apiRoot"
-        And the resource "/quality-on-demand/v0.11/retrieve-sessions"
+        And the resource "/quality-on-demand/vwip/retrieve-sessions"
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" is set to a UUID value
@@ -174,19 +174,6 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation retrieveSessionsByDev
 
     # Errors 403
 
-    @quality_on_demand_retrieveSessionsByDevice_403.1_device_token_mismatch
-    Scenario: Inconsistent access token context for the device
-        # To test this, a token have to be obtained for a different device
-        Given the request body property "$.device" is set to a valid testing device
-        And the header "Authorization" is set to a valid access token emitted for a different device
-        When the request "retrieveSessionsByDevice" is sent
-        Then the response status code is 403
-        And the response header "x-correlator" has same value as the request header "x-correlator"
-        And the response header "Content-Type" is "application/json"
-        And the response property "$.status" is 403
-        And the response property "$.code" is "INVALID_TOKEN_CONTEXT"
-        And the response property "$.message" contains a user friendly text
-
     # Errors 404
 
     # Typically with a 2-legged access token
@@ -199,12 +186,11 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation retrieveSessionsByDev
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 404
-        And the response property "$.code" is "DEVICE_NOT_FOUND"
+        And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
         And the response property "$.message" contains a user friendly text
 
     # Errors 422
 
-    # UNSUPPORTED_DEVICE_IDENTIFIERS is in the Commonalities guidelines (document) but it is not yet considered in the API spec
     @quality_on_demand_retrieveSessionsByDevice_422.1_device_identifiers_unsupported
     Scenario: None of the provided device identifiers is supported by the implementation
         Given that some type of device identifiers are not supported by the implementation
@@ -214,7 +200,7 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation retrieveSessionsByDev
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "UNPROCESSABLE_ENTITY"
+        And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
         And the response property "$.message" contains a user friendly text
 
     # This scenario is under discussion
@@ -227,7 +213,7 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation retrieveSessionsByDev
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "DEVICE_IDENTIFIERS_MISMATCH"
+        And the response property "$.code" is "IDENTIFIER_MISMATCH"
         And the response property "$.message" contains a user friendly text
 
     @quality_on_demand_retrieveSessionsByDevice_422.3_device_not_supported
@@ -239,7 +225,7 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation retrieveSessionsByDev
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "DEVICE_NOT_APPLICABLE"
+        And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
         And the response property "$.message" contains a user friendly text
 
     # Typically with a 2-legged access token
@@ -252,5 +238,32 @@ Feature: CAMARA Quality On Demand API, v0.11.1 - Operation retrieveSessionsByDev
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 422
-        And the response property "$.code" is "UNIDENTIFIABLE_DEVICE"
+        And the response property "$.code" is "MISSING_IDENTIFIER"
         And the response property "$.message" contains a user friendly text
+
+    # Typically with a 3-legged access token
+    @quality_on_demand_retrieveSessionsByDevice_422.5_device_token_mismatch
+    Scenario: Inconsistent access token context for the device
+        # To test this, a token has to be obtained for a different device
+        Given the request body property "$.device" is set to a valid testing device
+        And the header "Authorization" is set to a valid access token obtained for a different device
+        When the request "retrieveSessionsByDevice" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
+        And the response property "$.message" contains a user friendly text
+
+    # Typically with a 3-legged access token
+    @quality_on_demand_retrieveSessionsByDevice_422.6_unnecessary_device_identifier_in_request
+    Scenario: Explicit device identifier provided when device is identified by the access token
+        Given the request body property "$.device" is set to a valid testing device
+        And the header "Authorization" is set to a valid access token for that same device
+        When the request "retrieveSessionsByDevice" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
+        And the response property "$.message" contains a user friendly text     


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities [0.5.0-alpha.1](https://github.com/camaraproject/Commonalities/releases/tag/r2.1) updates the error response codes associated with device handling.

This PR:
- Updates the error response codes and schemas as necessary in the OAS definitions
- Updates the test cases as necessary
- Removes the `403 INVALID_TOKEN_CONTEXT` error from the OAS definitions
- Removes all 5XX errors as these no longer require to be explicitly documented
- Updates `info.description` text on device object handling in each OAS definition
- Ensures `date-time` examples are enclosed by quotation marks

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #390, #392, #389, #394

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Updates the error response codes and schemas as necessary in the OAS definitions
 - Updates the test cases as necessary
 - Removes the `403 INVALID_TOKEN_CONTEXT` error from the OAS definitions
 - Removes all 5XX errors as these no longer require to be explicitly documented
 - Updates `info.description` text on device object handling in each OAS definition
 - Ensures `date-time` examples are enclosed by quotation marks
```

#### Additional documentation 
None