### PR TITLE
Change notification sink format from url to uri

### DIFF
--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -385,7 +385,7 @@ components:
           $ref: "#/components/schemas/QosProfileName"
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         sinkCredential:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -485,7 +485,7 @@ components:
           $ref: "#/components/schemas/QosProfileName"
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events about all status changes of the session (e.g. session termination) shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         sinkCredential:


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities v0.5.0 will require notification sink format to be `uri` rather than `url`. This ensures RFC 3986 compliance. See [here](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#instance-based-implicit-subscription).

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #413 

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Change notification sink format from url to uri
```

#### Additional documentation 
None