### PR TITLE
Update wording in the qod-provisioning API

### DIFF
--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -6,7 +6,7 @@ info:
 
     The association resulting from the QoD provisioning request is represented by a QoD provisioning record (or QoD provisioning for short) that includes information about the date of provisioning, the QoS profile, the provisioning status, etc., as well as a provisioningId that uniquely identifies this record for later use.
 
-    In addition, this API sets up the configuration in the network such that the requested QoS profile is applied to a specified device, at any time while the association is available. The device traffic will be treated with the provisioned QoS profile by the network whenever the device is connected to the network, until the provisioning is revoked.
+    Additionally, this API configures the network to apply the requested QoS profile to a specified device whenever the device is connected to the network, until the provisioning is revoked.
 
     # Relevant terms and definitions
 

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -6,7 +6,8 @@ The Quality-on-Demand (QoD) Provisioning API offers a programmable interface for
 
 The association resulting from the QoD provisioning request is represented by a QoD provisioning record (or QoD provisioning for short) that includes information about the date of provisioning, the QoS profile, the provisioning status, etc., as well as a provisioningId uniquely identifying this record for later usage.
 
-    This API sets up the configuration in the network so the requested QoS profile is applied to a specified device, at any time while the association is available. The device traffic will be treated with a certain QoS profile by the network whenever the device is connected to the network, until the provisioning is revoked.
+In addition, this API sets up the configuration in the network such that the requested QoS profile is applied to a specified device, at any time while the association is available. The device traffic will be treated with the provisioned QoS profile by the network whenever the device is connected to the network, until the provisioning is revoked.
+
 
 
     # Relevant terms and definitions

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -2,13 +2,11 @@ openapi: 3.0.3
 info:
   title: QoD Provisioning API
   description: |
-The Quality-on-Demand (QoD) Provisioning API offers a programmable interface for developers to request the association of a certain QoS profile with a certain device, indefinitely.
+    The Quality-on-Demand (QoD) Provisioning API offers a programmable interface for developers to request the association of a certain QoS profile with a certain device, indefinitely.
 
-The association resulting from the QoD provisioning request is represented by a QoD provisioning record (or QoD provisioning for short) that includes information about the date of provisioning, the QoS profile, the provisioning status, etc., as well as a provisioningId uniquely identifying this record for later usage.
+    The association resulting from the QoD provisioning request is represented by a QoD provisioning record (or QoD provisioning for short) that includes information about the date of provisioning, the QoS profile, the provisioning status, etc., as well as a provisioningId uniquely identifying this record for later usage.
 
-In addition, this API sets up the configuration in the network such that the requested QoS profile is applied to a specified device, at any time while the association is available. The device traffic will be treated with the provisioned QoS profile by the network whenever the device is connected to the network, until the provisioning is revoked.
-
-
+    In addition, this API sets up the configuration in the network such that the requested QoS profile is applied to a specified device, at any time while the association is available. The device traffic will be treated with the provisioned QoS profile by the network whenever the device is connected to the network, until the provisioning is revoked.
 
     # Relevant terms and definitions
 
@@ -16,7 +14,7 @@ In addition, this API sets up the configuration in the network such that the req
     Latency, throughput or priority requirements of the application mapped to relevant QoS profile values. The set of QoS Profiles that a network operator is offering may be retrieved via the `qos-profiles` API (cf. https://github.com/camaraproject/QualityOnDemand/) or will be agreed during the onboarding with the API service provider.
 
     * **Identifier for the device**:
-    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the network operator for the device, at the request time. After the provisioning request is accepted, the device may get different IP addresses, but the provisioning will still apply to the device that was identified during the request process. Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
+    At least one identifier for the device out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the network operator for the device, at the request time. After the provisioning request is accepted, the device may get different IP addresses, but the provisioning will still apply to the device that was identified during the request process. Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Notification URL and token**:
     API consumers may provide a callback URL (`sink`) on which notifications about all status change events (eg. provisioning termination) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message. If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint.
@@ -232,7 +230,7 @@ paths:
     delete:
       tags:
         - QoD Provisioning
-      summary: Reverts a QoD provisioning
+      summary: Revokes a QoD provisioning
       description: |
         Revokes the association of a QoS profile with the device performed by a previous provisioning.
 
@@ -246,13 +244,13 @@ paths:
         - The access token may be either 2-legged or 3-legged.
         - If a 3-legged access token is used, the subject associated with the QoD provisioning must also be associated with the access token.
         - The QoD provisioning must have been created by the same API consumer given in the access token.
-      operationId: revertProvisioning
+      operationId: revokeProvisioning
       parameters:
         - $ref: "#/components/parameters/provisioningId"
         - $ref: "#/components/parameters/x-correlator"
       responses:
         "204":
-          description: Provisioning reverted
+          description: Provisioning revoked
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: QoD Provisioning API
   description: |
-    The Quality-on-Demand (QoD) Provisioning API offers a programmable interface for developers to request the association of a certain QoS profile with a certain device, indefinitely.
+    The Quality-on-Demand (QoD) Provisioning API provides a programmable interface for developers to request the association of a specific QoS profile with a device, indefinitely.
 
     The association resulting from the QoD provisioning request is represented by a QoD provisioning record (or QoD provisioning for short) that includes information about the date of provisioning, the QoS profile, the provisioning status, etc., as well as a provisioningId uniquely identifying this record for later usage.
 

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -234,7 +234,8 @@ paths:
         - QoD Provisioning
       summary: Reverts a QoD provisioning
       description: |
-        Revokes the assignment of a QoS profile to a device performed by a former provisioning.
+        Revokes the association of a QoS profile with the device performed by a previous provisioning.
+
 
         If the notification callback is provided and the provisioning status was `AVAILABLE`, when the process is completed, the API consumer will receive in addition to the response a `PROVISIONING_STATUS_CHANGED` event with
         - `status` as `UNAVAILABLE` and

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -4,7 +4,7 @@ info:
   description: |
     The Quality-on-Demand (QoD) Provisioning API provides a programmable interface for developers to request the association of a specific QoS profile with a device, indefinitely.
 
-    The association resulting from the QoD provisioning request is represented by a QoD provisioning record (or QoD provisioning for short) that includes information about the date of provisioning, the QoS profile, the provisioning status, etc., as well as a provisioningId uniquely identifying this record for later usage.
+    The association resulting from the QoD provisioning request is represented by a QoD provisioning record (or QoD provisioning for short) that includes information about the date of provisioning, the QoS profile, the provisioning status, etc., as well as a provisioningId that uniquely identifies this record for later use.
 
     In addition, this API sets up the configuration in the network such that the requested QoS profile is applied to a specified device, at any time while the association is available. The device traffic will be treated with the provisioned QoS profile by the network whenever the device is connected to the network, until the provisioning is revoked.
 

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -2,7 +2,9 @@ openapi: 3.0.3
 info:
   title: QoD Provisioning API
   description: |
-    The Quality-On-Demand (QoD) Provisioning API offers a programmable interface for developers to request the assignment of a certain QoS Profile to a certain device, indefinitely.
+The Quality-on-Demand (QoD) Provisioning API offers a programmable interface for developers to request the association of a certain QoS profile with a certain device, indefinitely.
+
+The association resulting from the QoD provisioning request is represented by a QoD provisioning record (or QoD provisioning for short) that includes information about the date of provisioning, the QoS profile, the provisioning status, etc., as well as a provisioningId uniquely identifying this record for later usage.
 
     This API sets up the configuration in the network so the requested QoS profile is applied to a specified device, at any time while the association is available. The device traffic will be treated with a certain QoS profile by the network whenever the device is connected to the network, until the provisioning is revoked.
 

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -401,7 +401,7 @@ components:
       description: |
         Provisioning related information returned in responses.
         Optional device object only to be returned if provided in triggerProvisioning. If more than one type of device identifier was provided, only one identifier will be returned (at implementation choice and with the original value provided in triggerProvisioning).
-        Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time of QoD provisioning.
+        Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time the QoD provisioning was triggered.
 
       allOf:
         - $ref: "#/components/schemas/BaseProvisioningInfo"

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -403,7 +403,8 @@ components:
       description: |
         Provisioning related information returned in responses.
         Optional device object only to be returned if provided in triggerProvisioning. If more than one type of device identifier was provided, only one identifier will be returned (at implementation choice and with the original value provided in triggerProvisioning).
-        Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time of QoD provisioning creation.
+        Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time of QoD provisioning.
+
       allOf:
         - $ref: "#/components/schemas/BaseProvisioningInfo"
         - type: object

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -22,7 +22,7 @@ info:
     # Resources and Operations overview
     The API defines four operations:
 
-    - An operation to setup a new QoD provisioning for a given device.
+    - An operation to set up a new QoD provisioning for a given device.
     - An operation to get the information about a specific QoD provisioning, identified by its `provisioningId`.
     - An operation to get the QoD provisioning for a given device.
     - An operation to revoke a QoD provisioning, identified by its `provisioningId`.

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -85,7 +85,7 @@ paths:
         - QoD Provisioning
       summary: Triggers a new provisioning of QoS for a device
       description: |
-        Triggers the provisioning in the operator's environment of the association of a given QoS profile with a given device.
+        Triggers the provisioning in the operator's environment to associate a given QoS profile with a given device.
 
 
         - If the provisioning is completed synchronously, the response will be 201 with `status` = `AVAILABLE`.

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -87,7 +87,8 @@ paths:
         - QoD Provisioning
       summary: Triggers a new provisioning of QoS for a device
       description: |
-        Triggers a new provisioning in the operator to assign certain QoS Profile to certain device.
+        Triggers the provisioning in the operator's environment of the association of a given QoS profile with a given device.
+
 
         - If the provisioning is completed synchronously, the response will be 201 with `status` = `AVAILABLE`.
         - If the provisioning request is accepted but not yet completed, the response will be 201 with `status` = `REQUESTED`.

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -307,7 +307,8 @@ paths:
         required: true
       responses:
         "200":
-          description: Returns information about QoD provisioning for the device.
+          description: Returns information about the QoD provisioning for the device.
+
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -4,7 +4,7 @@ info:
   description: |
     The Quality-On-Demand (QoD) Provisioning API offers a programmable interface for developers to request the assignment of a certain QoS Profile to a certain device, indefinitely.
 
-    This API sets up the configuration in the network so the requested QoS profile is applied to a specified device, at any time while the provisioning is available. The device traffic will be treated with a certain QoS profile by the network whenever the device is connected to the network, until the provisioning is deleted.
+    This API sets up the configuration in the network so the requested QoS profile is applied to a specified device, at any time while the association is available. The device traffic will be treated with a certain QoS profile by the network whenever the device is connected to the network, until the provisioning is revoked.
 
 
     # Relevant terms and definitions
@@ -24,7 +24,7 @@ info:
     - An operation to setup a new QoD provisioning for a given device.
     - An operation to get the information about a specific QoD provisioning, identified by its `provisioningId`.
     - An operation to get the QoD provisioning for a given device.
-    - An operation to terminate a QoD provisioning, identified by its `provisioningId`.
+    - An operation to revoke a QoD provisioning, identified by its `provisioningId`.
 
     # Authorization and authentication
 
@@ -50,7 +50,7 @@ info:
 
     # Multi-SIM scenario handling
 
-    In multi-SIM scenarios where more than one mobile device is associated with a phone number (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device to which the QoS provisioning should apply from that phone number. If the phone number is used as the device identifier when provisioning in a multi-SIM scenario, the API may respond with an error, apply the provisioning to all devices in the multi-SIM group, or apply the provisioning to a single device in the multi-SIM group which may not be the intended device.
+    In multi-SIM scenarios where more than one mobile device is associated with a phone number (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device to which the QoD provisioning should apply from that phone number. If the phone number is used as the device identifier when provisioning in a multi-SIM scenario, the API may respond with an error, apply the provisioning to all devices in the multi-SIM group, or apply the provisioning to a single device in the multi-SIM group which may not be the intended device.
 
     Possible solutions in such a scenario include:
     - Using the authorisation code flow to obtain an access token, which will automatically identify the intended device
@@ -82,7 +82,7 @@ paths:
     post:
       tags:
         - QoD Provisioning
-      summary: Sets a new provisioning of QoS for a device
+      summary: Triggers a new provisioning of QoS for a device
       description: |
         Triggers a new provisioning in the operator to assign certain QoS Profile to certain device.
 
@@ -100,15 +100,15 @@ paths:
           - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
           - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.
 
-      operationId: createProvisioning
+      operationId: triggerProvisioning
       parameters:
         - $ref: "#/components/parameters/x-correlator"
       requestBody:
-        description: Parameters to create a new provisioning
+        description: Parameters to trigger a new provisioning
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateProvisioning"
+              $ref: "#/components/schemas/TriggerProvisioning"
         required: true
       callbacks:
         notifications:
@@ -161,7 +161,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProvisioningInfo"
         "400":
-          $ref: "#/components/responses/CreateProvisioning400"
+          $ref: "#/components/responses/TriggerProvisioning400"
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
@@ -228,11 +228,11 @@ paths:
     delete:
       tags:
         - QoD Provisioning
-      summary: Deletes a QoD provisioning
+      summary: Reverts a QoD provisioning
       description: |
-        Release resources related to QoS provisioning.
+        Revokes the assignment of a QoS profile to a device performed by a former provisioning.
 
-        If the notification callback is provided and the provisioning status was `AVAILABLE`, when the deletion is completed, the API consumer will receive in addition to the response a `PROVISIONING_STATUS_CHANGED` event with
+        If the notification callback is provided and the provisioning status was `AVAILABLE`, when the process is completed, the API consumer will receive in addition to the response a `PROVISIONING_STATUS_CHANGED` event with
         - `status` as `UNAVAILABLE` and
         - `statusInfo` as `DELETE_REQUESTED`
         There will be no notification event if the `status` was already `UNAVAILABLE`.
@@ -241,13 +241,13 @@ paths:
         - The access token may be either 2-legged or 3-legged.
         - If a 3-legged access token is used, the subject associated with the QoD provisioning must also be associated with the access token.
         - The QoD provisioning must have been created by the same API consumer given in the access token.
-      operationId: deleteProvisioning
+      operationId: revertProvisioning
       parameters:
         - $ref: "#/components/parameters/provisioningId"
         - $ref: "#/components/parameters/x-correlator"
       responses:
         "204":
-          description: Provisioning deleted
+          description: Provisioning reverted
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"
@@ -302,7 +302,7 @@ paths:
         required: true
       responses:
         "200":
-          description: Returns information about QoS provisioning for the device.
+          description: Returns information about QoD provisioning for the device.
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"
@@ -396,7 +396,7 @@ components:
     ProvisioningInfo:
       description: |
         Provisioning related information returned in responses.
-        Optional device object only to be returned if provided in createProvisioning. If more than one type of device identifier was provided, only one identifier will be returned (at implementation choice and with the original value provided in createProvisioning).
+        Optional device object only to be returned if provided in triggerProvisioning. If more than one type of device identifier was provided, only one identifier will be returned (at implementation choice and with the original value provided in triggerProvisioning).
         Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time of QoD provisioning creation.
       allOf:
         - $ref: "#/components/schemas/BaseProvisioningInfo"
@@ -417,7 +417,7 @@ components:
             - provisioningId
             - status
 
-    CreateProvisioning:
+    TriggerProvisioning:
       description: Attributes to request a new QoD provisioning
       allOf:
         - $ref: "#/components/schemas/BaseProvisioningInfo"
@@ -770,7 +770,7 @@ components:
                 code: OUT_OF_RANGE
                 message: Client specified an invalid range.
 
-    CreateProvisioning400:
+    TriggerProvisioning400:
       description: Bad Request with additional errors for implicit notifications
       headers:
         x-correlator:

--- a/code/Test_definitions/qod-provisioning-getProvisioningById.feature
+++ b/code/Test_definitions/qod-provisioning-getProvisioningById.feature
@@ -5,7 +5,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
     # * apiRoot: API root of the server URL
     #
     # Testing assets:
-    # * The provisioningId of an existing QoD Provisiong, and the request properties used for createProvisioning
+    # * The provisioningId of an existing QoD Provisioning, and the request properties used for createProvisioning
     #
     # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml
 
@@ -14,16 +14,16 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
         Given an environment at "apiRoot"
         And the resource "/qod-provisioning/vwip/device-qos/{provisioningId}"                                                              |
         # Unless indicated otherwise the QoD provisioning must be created by the same API client given in the access token
-        And the header "Authorization" is set to a valid access token granted to the same client that created the QoD provisoning
+        And the header "Authorization" is set to a valid access token granted to the same client that created the QoD provisioning
         And the header "x-correlator" is set to a UUID value
-        And the path parameter "provisoningId" is set by default to an existing QoD provisioning ID
+        And the path parameter "provisioningId" is set by default to an existing QoD provisioning ID
 
     # Success scenarios
 
     @qod_provisioning_getProvisioningById_01_get_existing_qod_provisioning
     Scenario: Get an existing QoD Provisioning by provisioningId
         Given an existing QoD provisioning created by operation createProvisioning
-        And the path parameter "provisoningId" is set to the value for that QoD provisioning
+        And the path parameter "provisioningId" is set to the value for that QoD provisioning
         When the request "getProvisioningById" is sent
         Then the response status code is 200
         And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -34,14 +34,14 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
         And the response property "$.device" exists only if provided for createProvisioning and with the same value
         And the response property "$.qosProfile" has the value provided for createProvisioning
         And the response property "$.sink" exists only if provided for createProvisioning and with the same value
-        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatible for security concerns
+        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatable for security concerns
         And the response property "$.startedAt" exists only if "$.status" is not "REQUESTED" and the value is in the past
         And the response property "$.statusInfo" exists only if "$.status" is "UNAVAILABLE"
 
-    @qod_provisioning_getProvisioningById_02_get_recent_unvailable
+    @qod_provisioning_getProvisioningById_02_get_recent_unavailable
     Scenario: Provisioning becoming "UNAVAILABLE" is not released for at least 360 seconds
         Given an existing QoD provisioning deleted in the last 360 seconds
-        And the path parameter "provisoningId" is set to the value for that QoD provisioning
+        And the path parameter "provisioningId" is set to the value for that QoD provisioning
         When the request "getProvisioningById" is sent
         Then the response status code is 200
         And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -129,7 +129,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
 
     @qod_provisioning_getProvisioningById_404.1_not_found
     Scenario: provisioningId of a no existing QoD provisioning
-        Given the path parameter "provisoningId" is set to a random UUID
+        Given the path parameter "provisioningId" is set to a random UUID
         When the request "getProvisioningById" is sent
         Then the response status code is 404
         And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
+++ b/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
@@ -19,7 +19,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the resource "/qod-provisioning/vwip/retrieve-device-qos"                                                              |
         And the header "Content-Type" is set to "application/json"
         # Unless indicated otherwise the QoD provisioning must be created by the same API client given in the access token
-        And the header "Authorization" is set to a valid access token granted to the same client that created the QoD provisoning
+        And the header "Authorization" is set to a valid access token granted to the same client that created the QoD provisioning
         And the header "x-correlator" is set to a UUID value
 
     # Success scenarios
@@ -37,7 +37,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response property "$.device" exists only if provided for createProvisioning and with the same value
         And the response property "$.qosProfile" has the value provided for createProvisioning
         And the response property "$.sink" exists only if provided for createProvisioning and with the same value
-        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatible for security concerns
+        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatable for security concerns
         And the response property "$.startedAt" exists only if "$.status" is "AVAILABLE" and the value is in the past
         And the response property "$.statusInfo" exists only if "$.status" is "UNAVAILABLE"
 

--- a/code/Test_definitions/qod-provisioning-revokeProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-revokeProvisioning.feature
@@ -1,41 +1,41 @@
-Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
+Feature: CAMARA QoD Provisioning API, vwip - Operation revokeProvisioning
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
     # * apiRoot: API root of the server URL
     #
     # Testing assets:
-    # * The ProvisioningInfo of an existing QoD Provisiong
-    # * The ProvisioningInfo of an existing QoD Provisiong with status "AVAILABLE", and with provided values for "sink" and "sinkCredential"
+    # * The ProvisioningInfo of an existing QoD Provisioning
+    # * The ProvisioningInfo of an existing QoD Provisioning with status "AVAILABLE", and with provided values for "sink" and "sinkCredential"
     #
     # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml
 
 
-    Background: Common deleteProvisioning setup
+    Background: Common revokeProvisioning setup
         Given an environment at "apiRoot"
         And the resource "/qod-provisioning/vwip/device-qos/{provisioningId}"
         # Unless indicated otherwise the QoD provisioning must be created by the same API client given in the access token
-        And the header "Authorization" is set to a valid access token granted to the same client that created the QoD provisoning
+        And the header "Authorization" is set to a valid access token granted to the same client that created the QoD provisioning
         And the header "x-correlator" is set to a UUID value
-        And the path parameter "provisoningId" is set by default to an existing QoD provisioning ID
+        And the path parameter "provisioningId" is set by default to an existing QoD provisioning ID
 
     # Success scenarios
 
-    @qod_provisioning_deleteProvisioning_01_delete_existing_qod_provisioning_sync
+    @qod_provisioning_revokeProvisioning_01_delete_existing_qod_provisioning_sync
     Scenario: Delete an existing QoD Provisioning synchronously
         Given that implementation deletes QoD provisioning synchronously
         And an existing QoD provisioning created by operation createProvisioning
-        And the path parameter "provisoningId" is set to the value for that QoD provisioning
-        When the request "deleteProvisioning" is sent
+        And the path parameter "provisioningId" is set to the value for that QoD provisioning
+        When the request "revokeProvisioning" is sent
         Then the response status code is 204
         And the response header "x-correlator" has same value as the request header "x-correlator"
 
-    @qod_provisioning_deleteProvisioning_02_delete_existing_qod_provisioning_async
+    @qod_provisioning_revokeProvisioning_02_delete_existing_qod_provisioning_async
     Scenario: Delete an existing QoD Provisioning asynchronously
         Given that implementation deletes QoD provisioning asynchronously
         And an existing QoD provisioning created by operation createProvisioning
-        And the path parameter "provisoningId" is set to the value for that QoD provisioning
-        When the request "deleteProvisioning" is sent
+        And the path parameter "provisioningId" is set to the value for that QoD provisioning
+        When the request "revokeProvisioning" is sent
         Then the response status code is 202
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -47,15 +47,15 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
         And the response property "$.status" is "AVAILABLE"
         And the response property "$.statusInfo" is "DELETE_REQUESTED"
         And the response property "$.sink" exists only if provided for createProvisioning and with the same value
-        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatible for security concerns
+        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatable for security concerns
         And the response property "$.startedAt" exists and the value is in the past
 
-    @qod_provisioning_deleteProvisioning_03_event_notification_sync
+    @qod_provisioning_revokeProvisioning_03_event_notification_sync
     Scenario: Event is received if the provisioning was AVAILABLE and sink was provided (synchronous deletion)
         Given that implementation deletes QoD provisioning synchronously
         And an existing QoD provisioning created by operation createProvisioning with provided values for "sink" and "sinkCredential", and with status "AVAILABLE"
-        And the path parameter "provisoningId" is set to the value for that QoD provisioning
-        When the request "deleteProvisioning" is sent
+        And the path parameter "provisioningId" is set to the value for that QoD provisioning
+        When the request "revokeProvisioning" is sent
         Then the response status code is 204
         And an event is received at the address of the "$.sink" provided for createProvisioning
         And the event header "Authorization" is set to "Bearer: " + the value of "$.sinkCredentials.accessToken" provided for createProvisioning
@@ -68,12 +68,12 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
         And the event body property "$.data.status" is "UNAVAILABLE"
         And the event body property "$.data.statusInfo" is "DELETE_REQUESTED"
 
-    @qod_provisioning_deleteProvisioning_04_event_notification_async
+    @qod_provisioning_revokeProvisioning_04_event_notification_async
     Scenario: Event is received if the provisioning was AVAILABLE and sink was provided (asynchronous deletion)
         Given that implementation deletes QoD provisioning asynchronously
         And an existing QoD provisioning created by operation createProvisioning with provided values for "sink" and "sinkCredential", and with status "AVAILABLE"
-        And the path parameter "provisoningId" is set to the value for that QoD provisioning
-        When the request "deleteProvisioning" is sent
+        And the path parameter "provisioningId" is set to the value for that QoD provisioning
+        When the request "revokeProvisioning" is sent
         Then the response status code is 202
         And when the asynchronous deletion process is completed
         Then an event is received at the address of the "$.sink" provided for createProvisioning
@@ -91,10 +91,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
 
     # 400 errors are not expected for this operation unless the implementation validates the format of provisioningId
     # 404 NOT_FOUND is an alternative if path parameter format is not validated
-    @qod_provisioning_deleteProvisioning_400.1_invalid_id
+    @qod_provisioning_revokeProvisioning_400.1_invalid_id
     Scenario: Invalid Argument. Generic Syntax Exception
         Given the path parameter "provisioningId" has not a UUID format
-        When the request "deleteProvisioning" is sent
+        When the request "revokeProvisioning" is sent
         Then the response status code is 404
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -104,10 +104,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
 
     # Generic 401 errors
 
-    @qod_provisioning_deleteProvisioning_401.1_no_authorization_header
+    @qod_provisioning_revokeProvisioning_401.1_no_authorization_header
     Scenario: No Authorization header
         Given the header "Authorization" is not sent
-        When the request "deleteProvisioning" is sent
+        When the request "revokeProvisioning" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -116,10 +116,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
         And the response property "$.message" contains a user friendly text
 
     # In this case both codes could make sense depending on whether the access token can be refreshed or not
-    @qod_provisioning_deleteProvisioning_401.2_expired_access_token
+    @qod_provisioning_revokeProvisioning_401.2_expired_access_token
     Scenario: Expired access token
         Given the header "Authorization" is set to an expired access token
-        When the request "deleteProvisioning" is sent
+        When the request "revokeProvisioning" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -127,10 +127,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
         And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_deleteProvisioning_401.3_invalid_access_token
+    @qod_provisioning_revokeProvisioning_401.3_invalid_access_token
     Scenario: Invalid access token
         Given the header "Authorization" is set to an invalid access token
-        When the request "deleteProvisioning" is sent
+        When the request "revokeProvisioning" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -140,10 +140,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
 
     # Errors 403
 
-    @qod_provisioning_deleteProvisioning_403.1_missing_access_token_scope
+    @qod_provisioning_revokeProvisioning_403.1_missing_access_token_scope
     Scenario: Missing access token scope
         Given the header "Authorization" is set to an access token that does not include scope qod-provisioning:device-qos:delete
-        When the request "deleteProvisioning" is sent
+        When the request "revokeProvisioning" is sent
         Then the response status code is 403
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -151,11 +151,11 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
         And the response property "$.code" is "PERMISSION_DENIED"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_deleteProvisioning_403.2_different_client_id
+    @qod_provisioning_revokeProvisioning_403.2_different_client_id
     Scenario: QoD provisioning not created by the API client given in the access token
         # To test this, a token have to be obtained by a different client
         Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoD provisioning
-        When the request "deleteProvisioning" is sent
+        When the request "revokeProvisioning" is sent
         Then the response status code is 403
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -165,10 +165,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation deleteProvisioning
 
     # Errors 404
 
-    @qod_provisioning_deleteProvisioning_404.1_not_found
+    @qod_provisioning_revokeProvisioning_404.1_not_found
     Scenario: provisioningId of a no existing QoD provisioning
-        Given the path parameter "provisoningId" is set to a random UUID
-        When the request "deleteProvisioning" is sent
+        Given the path parameter "provisioningId" is set to a random UUID
+        When the request "revokeProvisioning" is sent
         Then the response status code is 404
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/qod-provisioning-triggerProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-triggerProvisioning.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
+Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -13,23 +13,23 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
     # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml
 
 
-    Background: Common createProvisioning setup
+    Background: Common triggerProvisioning setup
         Given an environment at "apiRoot"
         And the resource "/qod-provisioning/vwip/device-qos"                                                              |
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" is set to a UUID value
-        # Properties not explicitly overwitten in the Scenarios can take any values compliant with the schema
-        And the request body is set by default to a request body compliant with the schema at "/components/schemas/CreateProvisioning"
+        # Properties not explicitly overwritten in the Scenarios can take any values compliant with the schema
+        And the request body is set by default to a request body compliant with the schema at "/components/schemas/triggerProvisioning"
 
     # Success scenarios
 
-    @qod_provisioning_createProvisioning_01_generic_success_scenario
-    Scenario: Common validations for any sucess scenario
+    @qod_provisioning_triggerProvisioning_01_generic_success_scenario
+    Scenario: Common validations for any success scenario
         # Valid testing device and default request body compliant with the schema
         Given a valid testing device supported by the service, identified by the token or provided in the request body
         And the request property "$.qosProfile" is set to a valid QoS Profile as returned by QoS Profiles API
-        When the request "createProvisioning" is sent
+        When the request "triggerProvisioning" is sent
         Then the response status code is 201
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -39,11 +39,11 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.device" exists only if provided in the request body and with the same value
         And the response property "$.qosProfile" has the same value as in the request body
         And the response property "$.sink" exists only if provided in the request body and with the same value
-        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatible for security concerns
+        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatable for security concerns
         And the response property "$.startedAt" exists only if "$.status" is "AVAILABLE" and the value is in the past
         And the response property "$.statusInfo" exists only if "$.status" is "UNAVAILABLE"
 
-    @qod_provisioning_createProvisioning_02_event_notification
+    @qod_provisioning_triggerProvisioning_02_event_notification
     Scenario: Events for the outcome of provisioning creation if sink is provided
         Given a valid testing device supported by the service, identified by the token or provided in the request body
         And the request property "$.qosProfile" is set to a valid QoS Profile as returned by QoS Profiles API
@@ -52,7 +52,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the request property "$.sinkCredentials.accessTokenType" is set to "bearer"
         And the request property "$.sinkCredentials.accessToken" is set to a valid access token accepted by the events receiver
         And the request property "$.sinkCredentials.accessTokenExpiresUtc" is set to a value long enough in the future
-        And the request "createProvisioning" is sent
+        And the request "triggerProvisioning" is sent
         And the response status code is 201
         # There is no specific limit defined for the process to end
         When the provisioning outcome is known
@@ -63,15 +63,15 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         # Additionally any event body has to comply with some constraints beyond the schema compliance
         And the event body property "$.id" is unique
         And the event body property "$.type" is set to "org.camaraproject.qod-provisioning.v0.status-changed"
-        And the event body property "$.data.provisioningId" has the same value as createProvisioning response property "$.provisioningId"
+        And the event body property "$.data.provisioningId" has the same value as triggerProvisioning response property "$.provisioningId"
         And the event body property "$.data.status" is "AVAILABLE" or "UNAVAILABLE"
         And the event body property "$.data.statusInfo" exists only if "$.data.status" is "UNAVAILABLE"
 
-    @qod_provisioning_createProvisioning_03_3_legged_missing_device
+    @qod_provisioning_triggerProvisioning_03_3_legged_missing_device
     Scenario: Device is not returned if not included in the creation request
         Given the header "Authorization" is set to a valid 3-legged access token associated to a valid testing device supported by the service
         And the request property "$.device" is not included
-        When the request "createProvisioning" is sent
+        When the request "triggerProvisioning" is sent
         Then the response status code is 201
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -80,7 +80,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
 
     # Common error scenarios for management of input parameter device
 
-    @qod_provisioning_createProvisioning_C01.01_device_empty
+    @qod_provisioning_triggerProvisioning_C01.01_device_empty
     Scenario: The device value is an empty object
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" is set to: {}
@@ -91,7 +91,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.message" contains a user friendly text
 
 
-    @qod_provisioning_createProvisioning_C01.02_device_identifiers_not_schema_compliant
+    @qod_provisioning_triggerProvisioning_C01.02_device_identifiers_not_schema_compliant
     Scenario Outline: Some device identifier value does not comply with the schema
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
@@ -110,7 +110,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
 
   
     # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.
-    @qod_provisioning_createProvisioning_C01.03_device_not_found
+    @qod_provisioning_triggerProvisioning_C01.03_device_not_found
     Scenario: Some identifier cannot be matched to a device
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" is compliant with the schema but does not identify a valid device
@@ -121,7 +121,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.message" contains a user friendly text
 
 
-    @qod_provisioning_createProvisioning_C01.04_unnecessary_device
+    @qod_provisioning_triggerProvisioning_C01.04_unnecessary_device
     Scenario: Device not to be included when it can be deduced from the access token
         Given the header "Authorization" is set to a valid access token identifying a device
         And the request body property "$.device" is set to a valid device
@@ -132,7 +132,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.message" contains a user-friendly text
 
 
-    @qod_provisioning_createProvisioning_C01.05_missing_device
+    @qod_provisioning_triggerProvisioning_C01.05_missing_device
     Scenario: Device not included and cannot be deduced from the access token
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" is not included
@@ -143,7 +143,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.message" contains a user-friendly text
 
 
-    @qod_provisioning_createProvisioning_C01.06_unsupported_device
+    @qod_provisioning_triggerProvisioning_C01.06_unsupported_device
     Scenario: None of the provided device identifiers is supported by the implementation
         Given that some types of device identifiers are not supported by the implementation
         And the header "Authorization" is set to a valid access token which does not identify a single device
@@ -156,7 +156,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
 
 
     # When the service is only offered to certain types of devices or subscriptions, e.g. IoT, B2C, etc.
-    @qod_provisioning_createProvisioning_C01.07_device_not_supported
+    @qod_provisioning_triggerProvisioning_C01.07_device_not_supported
     Scenario: Service not available for the device
         Given that the service is not available for all devices commercialized by the operator
         And a valid device, identified by the token or provided in the request body, for which the service is not applicable
@@ -169,7 +169,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
 
     # Several identifiers provided but they do not identify the same device
     # This scenario may happen with 2-legged access tokens, which do not identify a device
-    @qod_provisioning_createProvisioning_C01.08_device_identifiers_mismatch
+    @qod_provisioning_triggerProvisioning_C01.08_device_identifiers_mismatch
     Scenario: Device identifiers mismatch
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And at least 2 types of device identifiers are supported by the implementation
@@ -182,10 +182,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
 
     # Errors 400
 
-    @qod_provisioning_createProvisioning_400.1_schema_not_compliant
+    @qod_provisioning_triggerProvisioning_400.1_schema_not_compliant
     Scenario: Invalid Argument. Generic Syntax Exception
-        Given the request body is set to any value which is not compliant with the schema at "/components/schemas/CreateProvisioning"
-        When the request "createProvisioning" is sent
+        Given the request body is set to any value which is not compliant with the schema at "/components/schemas/triggerProvisioning"
+        When the request "triggerProvisioning" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -193,10 +193,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.code" is "INVALID_ARGUMENT"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_createProvisioning_400.2_no_request_body
+    @qod_provisioning_triggerProvisioning_400.2_no_request_body
     Scenario: Missing request body
         Given the request body is not included
-        When the request "createProvisioning" is sent
+        When the request "triggerProvisioning" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -204,10 +204,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.code" is "INVALID_ARGUMENT"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_createProvisioning_400.3_empty_request_body
+    @qod_provisioning_triggerProvisioning_400.3_empty_request_body
     Scenario: Empty object as request body
         Given the request body is set to {}
-        When the request "createProvisioning" is sent
+        When the request "triggerProvisioning" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -216,10 +216,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.message" contains a user friendly text
 
     # PLAIN and REFRESHTOKEN are considered in the schema so INVALID_ARGUMENT is not expected
-    @qod_provisioning_createProvisioning_400.7_invalid_sink_credential
+    @qod_provisioning_triggerProvisioning_400.7_invalid_sink_credential
     Scenario Outline: Invalid credential
         Given the request body property  "$.sinkCredential.credentialType" is set to "<unsupported_credential_type>"
-        When the request "createProvisioning" is sent
+        When the request "triggerProvisioning" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -234,10 +234,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
 
     # Only "bearer" is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction,
     # and both could be accepted
-    @qod_provisioning_createProvisioning_400.8_sink_credential_invalid_token
+    @qod_provisioning_triggerProvisioning_400.8_sink_credential_invalid_token
     Scenario: Invalid token
         Given the request body property  "$.sinkCredential.accessTokenType" is set to a value other than "bearer"
-        When the request "createProvisioning" is sent
+        When the request "triggerProvisioning" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -246,10 +246,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.message" contains a user friendly text
 
     # TBD if we neeed a dedicated code
-    @qod_provisioning_createProvisioning_400.9_non_existent_qos_profile
+    @qod_provisioning_triggerProvisioning_400.9_non_existent_qos_profile
     Scenario: Non existent QoS profile
         Given the request body property "qosProfile" is set to a non-existent QoS Profile
-        When the request "createProvisioning" is sent
+        When the request "triggerProvisioning" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -259,10 +259,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
 
     # Generic 401 errors
 
-    @qod_provisioning_createProvisioning_401.1_no_authorization_header
+    @qod_provisioning_triggerProvisioning_401.1_no_authorization_header
     Scenario: No Authorization header
         Given the header "Authorization" is removed
-        When the request "createProvisioning" is sent
+        When the request "triggerProvisioning" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -271,10 +271,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.message" contains a user friendly text
 
     # In this case both codes could make sense depending on whether the access token can be refreshed or not
-    @qod_provisioning_createProvisioning_401.2_expired_access_token
+    @qod_provisioning_triggerProvisioning_401.2_expired_access_token
     Scenario: Expired access token
         Given the header "Authorization" is set to an expired access token
-        When the request "createProvisioning" is sent
+        When the request "triggerProvisioning" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -282,10 +282,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
         And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_createProvisioning_401.3_invalid_access_token
+    @qod_provisioning_triggerProvisioning_401.3_invalid_access_token
     Scenario: Invalid access token
         Given the header "Authorization" is set to an invalid access token
-        When the request "createProvisioning" is sent
+        When the request "triggerProvisioning" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -295,10 +295,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
 
     # Errors 403
 
-    @qod_provisioning_createProvisioning_403.1_missing_access_token_scope
+    @qod_provisioning_triggerProvisioning_403.1_missing_access_token_scope
     Scenario: Missing access token scope
         Given the header "Authorization" is set to an access token that does not include scope qod-provisioning:device-qos:create
-        When the request "createProvisioning" is sent
+        When the request "triggerProvisioning" is sent
         Then the response status code is 403
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -308,11 +308,11 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation createProvisioning
 
     # Errors 409
 
-    @qod_provisioning_createProvisioning_409.1_provisioning_conflict
+    @qod_provisioning_triggerProvisioning_409.1_provisioning_conflict
     Scenario: Provisioning conflict
         Given a valid testing device supported by the service, identified by the token or provided in the request body
         And a QoD provisioning already exists for that device
-        When the request "createProvisioning" is sent
+        When the request "triggerProvisioning" is sent
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 409


### PR DESCRIPTION
#### What type of PR is this?

* documentation


#### What this PR does / why we need it:

Being "provisioning" a process and not a "resource", it does not sound well to create or delete a provisioning, but to trigger the process or to revert or revoke the assignments done by a previous provisioning process.


#### Which issue(s) this PR fixes:

Adresses part of #415 but will not close it

#### Special notes for reviewers:

Only some descriptions and operationIds have been adjusted for this Meta, as there is no a clear alternative for the names of the resources used in path, scopes, etc, and this change is critical to be done for this Meta-release without a thoughtful discussion.

As this is still an initial version of the API we will work further on those aspects towards a future meta-release, taking feedback from early integrations.


#### Changelog input

```
- operationIds renamed and some descriptions changed

```

#### Additional documentation 

This section can be blank.



```
docs

```
