### PR TITLE
[quality-on-demand]: Add HTTP-422 when qos profile is not applicable during session creation

### DIFF
--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -78,6 +78,8 @@ info:
 
     - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
 
+    - If the requested qosProfile exists but is currently not available for creating a session (e.g., its status is INACTIVE or DEPRECATED), then the server will return an error with the `422 QUALITY_ON_DEMAND.QOS_PROFILE_NOT_APPLICABLE` error code.
+
     # Multi-SIM scenario handling
 
     In multi-SIM scenarios where more than one mobile device is associated with a phone number (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device to which the enhanced QoS profile should apply from that phone number. If the phone number is used as the device identifier when creating a QoS session in a multi-SIM scenario, the API may respond with an error, apply the enhanced QoS profile to all devices in the multi-SIM group, or apply the enhanced QoS profile to a single device in the multi-SIM group which may not be the intended device.
@@ -188,6 +190,8 @@ paths:
                   $ref: "#/components/responses/Generic403"
                 "410":
                   $ref: "#/components/responses/Generic410"
+                "422":
+                  $ref: "#/components/responses/CreateSessionUnprocessableEntity422"
               security:
                 - {}
                 - notificationsBearerAuth: []
@@ -1347,6 +1351,31 @@ components:
                 status: 422
                 code: UNNECESSARY_IDENTIFIER
                 message: The device is already identified by the access token.
+    CreateSessionUnprocessableEntity422:
+      description: Unprocessable Content
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 422
+                  code:
+                    enum:
+                      - QUALITY_ON_DEMAND.QOS_PROFILE_NOT_APPLICABLE
+          examples:
+            QUALITY_ON_DEMAND_422_QOS_PROFILE_NOT_APPLICABLE:
+              description: The requested QoS Profile exists but cannot be used to create a session.
+              value:
+                status: 422
+                code: QUALITY_ON_DEMAND.QOS_PROFILE_NOT_APPLICABLE
+                message: The requested QoS Profile is currently not available for session creation.
 
     Generic429:
       description: Too Many Requests

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -382,3 +382,17 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
         And the response property "$.status" is 409
         And the response property "$.code" is "CONFLICT"
         And the response property "$.message" contains a user friendly text
+
+    # Errors 422
+
+    @quality_on_demand_createSession_422.1_session_qos_profile_not_applicable
+    Scenario: QoS Profile not applicable for session creation
+        Given a valid testing device supported by the service, identified by the token or provided in the request body
+        And the requested QoS Profile exists but is not applicable for the session
+        When the request "createSession" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "QUALITY_ON_DEMAND.QOS_PROFILE_NOT_APPLICABLE"
+        And the response property "$.message" contains a user friendly text


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature


#### What this PR does / why we need it:
This PR adds  the HTTP-422 with error code `QUALITY_ON_DEMAND.QOS_PROFILE_NOT_APPLICABLE`, when a session is unable to be created due to an existing, but unavailable QoS-profile



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #419 

#### Changelog input

```
 release-note
   * quality-on-demand]: Add HTTP-422 when qos profile is not applicable during session creation
```
