### PR TITLE
Adding new query atttributes for retrieve QoS profile

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -451,7 +451,15 @@ components:
 
     QosProfileDeviceRequest:
       description: |
-        Request object for QoS Profiles for a given device
+        Request object for QoS Profiles for a given device.
+        When attributes are specified, only profiles that meet or exceed the requested capabilities will be returned:
+        - Rate attributes (targetMinUpstreamRate, maxUpstreamRate, etc.): returned profiles will have rates greater than or equal to the requested values
+        - Duration attributes:
+          - minDuration: returned profiles will have minDuration less than or equal to the requested value
+          - maxDuration: returned profiles will have maxDuration greater than or equal to the requested value
+        - Priority: returned profiles will have priority less than or equal to the requested value (lower values = higher priority)
+        - Jitter & packetDelayBudget: returned profiles will have values less than or equal to the requested values
+        - packetErrorLossRate: returned profiles will have values less than or equal to the requested value
       type: object
       properties:
         device:
@@ -460,6 +468,57 @@ components:
           $ref: "#/components/schemas/QosProfileName"
         status:
           $ref: '#/components/schemas/QosProfileStatusEnum'
+        targetMinUpstreamRate:
+          $ref: "#/components/schemas/Rate"
+        maxUpstreamRate:
+          $ref: "#/components/schemas/Rate"
+        maxUpstreamBurstRate:
+          $ref: "#/components/schemas/Rate"
+        targetMinDownstreamRate:
+          $ref: "#/components/schemas/Rate"
+        maxDownstreamRate:
+          $ref: "#/components/schemas/Rate"
+        maxDownstreamBurstRate:
+          $ref: "#/components/schemas/Rate"
+        minDuration:
+          $ref: "#/components/schemas/Duration"
+        maxDuration:
+          $ref: "#/components/schemas/Duration"
+        priority:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 100
+        packetDelayBudget:
+          $ref: "#/components/schemas/Duration"
+        jitter:
+          $ref: "#/components/schemas/Duration"
+        packetErrorLossRate:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 10
+        l4sQueueType:
+          type: string
+          enum:
+            - non-l4s-queue
+            - l4s-queue
+            - mixed-queue
+        serviceClass:
+          type: string
+          enum:
+            - microsoft_voice
+            - microsoft_audio_video
+            - real_time_interactive
+            - multimedia_streaming
+            - broadcast_video
+            - low_latency_data
+            - high_throughput_data
+            - low_priority_data
+            - standard
+      required:
+        - name
+        - status
 
     Device:
       description: |

--- a/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
@@ -262,3 +262,85 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
         And the response property "$.code" is "PERMISSION_DENIED"
         And the response property "$.message" contains a user friendly text
 
+    @qos_profiles_retrieveQoSProfiles_07_filter_by_rate_attributes
+    Scenario Outline: Filter QoS profiles by rate attributes
+        Given the request body property "<rate_attribute>" is set to a valid Rate object
+        When the request "retrieveQoSProfiles" is sent
+        Then the response status code is 200
+        And the response header "Content-Type" is "application/json"
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And each item of the response array, if any, has "<rate_attribute>" greater than or equal to the requested value
+
+        Examples:
+            | rate_attribute           |
+            | targetMinUpstreamRate    |
+            | maxUpstreamRate         |
+            | maxUpstreamBurstRate    |
+            | targetMinDownstreamRate  |
+            | maxDownstreamRate       |
+            | maxDownstreamBurstRate  |
+
+    @qos_profiles_retrieveQoSProfiles_08_filter_by_duration_attributes
+    Scenario Outline: Filter QoS profiles by duration attributes
+        Given the request body property "<duration_attribute>" is set to a valid Duration object
+        When the request "retrieveQoSProfiles" is sent
+        Then the response status code is 200
+        And the response header "Content-Type" is "application/json"
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And each item of the response array, if any, has "<duration_attribute>" <comparison> the requested value
+
+        Examples:
+            | duration_attribute  | comparison              |
+            | minDuration        | less than or equal to    |
+            | maxDuration        | greater than or equal to |
+
+    @qos_profiles_retrieveQoSProfiles_09_filter_by_latency_attributes
+    Scenario Outline: Filter QoS profiles by latency attributes
+        Given the request body property "<latency_attribute>" is set to a valid Duration object
+        When the request "retrieveQoSProfiles" is sent
+        Then the response status code is 200
+        And the response header "Content-Type" is "application/json"
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And each item of the response array, if any, has "<latency_attribute>" less than or equal to the requested value
+
+        Examples:
+            | latency_attribute  |
+            | packetDelayBudget |
+            | jitter           |
+
+    @qos_profiles_retrieveQoSProfiles_10_filter_by_priority
+    Scenario: Filter QoS profiles by priority
+        Given the request body property "priority" is set to a valid priority value
+        When the request "retrieveQoSProfiles" is sent
+        Then the response status code is 200
+        And the response header "Content-Type" is "application/json"
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And each item of the response array, if any, has priority less than or equal to the requested value
+
+    @qos_profiles_retrieveQoSProfiles_11_filter_by_packet_error_loss_rate
+    Scenario: Filter QoS profiles by packet error loss rate
+        Given the request body property "packetErrorLossRate" is set to a valid value
+        When the request "retrieveQoSProfiles" is sent
+        Then the response status code is 200
+        And the response header "Content-Type" is "application/json"
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And each item of the response array, if any, has packetErrorLossRate less than or equal to the requested value
+
+    @qos_profiles_retrieveQoSProfiles_12_filter_by_l4s_queue_type
+    Scenario: Filter QoS profiles by L4S queue type
+        Given the request body property "l4sQueueType" is set to a valid queue type
+        When the request "retrieveQoSProfiles" is sent
+        Then the response status code is 200
+        And the response header "Content-Type" is "application/json"
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And each item of the response array, if any, has l4sQueueType equal to the requested value
+
+    @qos_profiles_retrieveQoSProfiles_13_filter_by_service_class
+    Scenario: Filter QoS profiles by service class
+        Given the request body property "serviceClass" is set to a valid service class
+        When the request "retrieveQoSProfiles" is sent
+        Then the response status code is 200
+        And the response header "Content-Type" is "application/json"
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And each item of the response array, if any, has serviceClass equal to the requested value
+


### PR DESCRIPTION

#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature


#### What this PR does / why we need it:

Adds new query capabilites

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #147

#### Special notes for reviewers:



#### Changelog input

```
 release-note
Enhanced filtering capabilities in the /retrieve-qos-profiles endpoint:
Added support for filtering by all QoS profile attributes including rates, durations, priority, latency, and service classes
Clarified comparison logic for different types of attributes:
Rate attributes: returned profiles have values greater than or equal to requested
Duration attributes:
minDuration: profiles have values less than or equal to requested
maxDuration: profiles have values greater than or equal to requested
Priority: profiles have values less than or equal to requested (lower = higher priority)
Latency attributes (jitter, packetDelayBudget): profiles have values less than or equal to requested
packetErrorLossRate: profiles have values less than or equal to requested
l4sQueueType and serviceClass: profiles match exactly

```

#### Additional documentation 

This section can be blank.



```
docs

```
