### PR TITLE
Add country availability field to QoS profile

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -204,6 +204,18 @@ components:
             A description of the QoS profile.
           type: string
           example: "QoS profile for video streaming"
+        countryAvailablility:
+          description: A list of countries in which the API provider makes the profile available.
+                       - When profiles are filtered for a specific device (i.e. using a 3-legged access token or an explicit device filter parameter), the profile can be used by that device in any of these countries when connected to the API provider's network.
+                       - When there is no device filter, availability in a given country means that the profile will be available to some devices connected to the API provider's network, but not necessarily to all devices.
+                       - If this field is not present in the QoS profile, no assumption can be made about the availability of the profile in any given country
+          type: array
+            items:
+              type: string
+              description: The two letter ISO 3166-2 country code for the country in which the QoS profile is available
+              pattern: '^[A-Z]{2}$'
+              example: "GB"
+            example: "[ "GB", "DE", "FR", "IT", "ES" ]"
         status:
           $ref: "#/components/schemas/QosProfileStatusEnum"
         targetMinUpstreamRate:

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -207,10 +207,11 @@ components:
         status:
           $ref: "#/components/schemas/QosProfileStatusEnum"
         countryAvailablility:
-          description: A list of countries in which the API provider makes the profile available.
-                       - When profiles are filtered for a specific device (i.e. using a 3-legged access token or an explicit device filter parameter), the profile can be used by that device in any of these countries when connected to the API provider's network.
-                       - When there is no device filter, availability in a given country means that the profile will be available to some devices connected to the API provider's network, but not necessarily to all devices.
-                       - If this field is not present in the QoS profile, no assumption can be made about the availability of the profile in any given country
+          description: |
+            A list of countries in which the API provider makes the profile available.
+            - When profiles are filtered for a specific device (i.e. using a 3-legged access token or an explicit device filter parameter), the profile can be used by that device in any of these countries when connected to the API provider's network.
+            - When there is no device filter, availability in a given country means that the profile will be available to some devices connected to the API provider's network, but not necessarily to all devices.
+            - If this field is not present in the QoS profile, no assumption can be made about the availability of the profile in any given country
           type: array
           items:
             type: string

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -204,6 +204,8 @@ components:
             A description of the QoS profile.
           type: string
           example: "QoS profile for video streaming"
+        status:
+          $ref: "#/components/schemas/QosProfileStatusEnum"
         countryAvailablility:
           description: A list of countries in which the API provider makes the profile available.
                        - When profiles are filtered for a specific device (i.e. using a 3-legged access token or an explicit device filter parameter), the profile can be used by that device in any of these countries when connected to the API provider's network.
@@ -216,8 +218,6 @@ components:
             pattern: '^[A-Z]{2}$'
             example: "GB"
           example: '[ "GB", "DE", "FR", "IT", "ES" ]'
-        status:
-          $ref: "#/components/schemas/QosProfileStatusEnum"
         targetMinUpstreamRate:
           description: |
             This is the target minimum upload speed for the QoS profile.

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -210,12 +210,12 @@ components:
                        - When there is no device filter, availability in a given country means that the profile will be available to some devices connected to the API provider's network, but not necessarily to all devices.
                        - If this field is not present in the QoS profile, no assumption can be made about the availability of the profile in any given country
           type: array
-            items:
-              type: string
-              description: The two letter ISO 3166-2 country code for the country in which the QoS profile is available
-              pattern: '^[A-Z]{2}$'
-              example: "GB"
-            example: "[ "GB", "DE", "FR", "IT", "ES" ]"
+          items:
+            type: string
+            description: The two letter ISO 3166-2 country code for the country in which the QoS profile is available
+            pattern: '^[A-Z]{2}$'
+            example: "GB"
+          example: '[ "GB", "DE", "FR", "IT", "ES" ]'
         status:
           $ref: "#/components/schemas/QosProfileStatusEnum"
         targetMinUpstreamRate:


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
Adds a `countryAvailability` field to the QoS profile to allow an API provider to indicate in which countries the profile is available

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #431 

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Adds a countryAvailability field to the QoS profile to allow an API provider to indicate in which countries the profile is available
```

#### Additional documentation 
None