### PR TITLE
Remove AUTHENTICATION_REQUIRED error

### DIFF
--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -847,20 +847,13 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
-                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
-            GENERIC_401_AUTHENTICATION_REQUIRED:
-              description: New authentication is needed, authentication is no longer valid
-              value:
-                status: 401
-                code: AUTHENTICATION_REQUIRED
-                message: New authentication is required.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
 
     Generic403:
       description: Forbidden

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -614,20 +614,13 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
-                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
-            GENERIC_401_AUTHENTICATION_REQUIRED:
-              description: New authentication is needed, authentication is no longer valid
-              value:
-                status: 401
-                code: AUTHENTICATION_REQUIRED
-                message: New authentication is required.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
 
     Generic403:
       description: Forbidden

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -1121,20 +1121,13 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
-                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
-            GENERIC_401_AUTHENTICATION_REQUIRED:
-              description: New authentication is needed, authentication is no longer valid
-              value:
-                status: 401
-                code: AUTHENTICATION_REQUIRED
-                message: New authentication is required.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
 
     Generic403:
       description: Forbidden

--- a/code/Test_definitions/README.md
+++ b/code/Test_definitions/README.md
@@ -8,7 +8,6 @@ The test plan has to be enhanced and some scenarios still contains comments and 
 * For port ranges, the maximum is considered in the schema so a generic schema validator may generate a 400 INVALID_ARGUMENT without further distinction, instead of the specific 400 OUT_OF_RANGE, so both could be accepted
 * For `sinkCredential.accessTokenType`, only `bearer` is considered in the schema so a generic schema validator may generate a 400 INVALID_ARGUMENT without further distinction, instead of the specific 400 INVALID_TOKEN, so both could be accepted
 * When providing a non existent QoS Profile to create a session or provisioning, what code to return? 400 INVALID_ARGUMENT is proposed
-* For expired tokens, both codes "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED" for 401 may be returned, depending on whether the access token can be refreshed or not
 * Now that QoS Profiles may be restricted to certain devices, what code to return when the provided device in createSession is not suitable for the provided qosProfile. We may reuse 422 SERVICE_NOT_APPLICABLE
 * When providing a path parameter, such sessionId or provisioningId, which is not compliant with the spec format (UUID), what code to return? Options are 400 INVALID_ARGUMENT or 404 NOT_FOUND if path parameter format is not checked previously
 * For QoS Profile response validations, it is pending to check additional constraints, such as minDuration being less or equal than maxDuration, etc

--- a/code/Test_definitions/qod-provisioning-getProvisioningById.feature
+++ b/code/Test_definitions/qod-provisioning-getProvisioningById.feature
@@ -86,7 +86,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 401
-        And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+        And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
     @qod_provisioning_getProvisioningById_401.3_invalid_access_token

--- a/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
+++ b/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
@@ -200,7 +200,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 401
-        And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+        And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
     @qod_provisioning_retrieveProvisioningByDevice_401.3_invalid_access_token

--- a/code/Test_definitions/qod-provisioning-revokeProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-revokeProvisioning.feature
@@ -124,7 +124,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation revokeProvisioning
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 401
-        And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+        And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
     @qod_provisioning_revokeProvisioning_401.3_invalid_access_token

--- a/code/Test_definitions/qod-provisioning-triggerProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-triggerProvisioning.feature
@@ -279,7 +279,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 401
-        And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+        And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
     @qod_provisioning_triggerProvisioning_401.3_invalid_access_token

--- a/code/Test_definitions/qos-profiles-getQosProfile.feature
+++ b/code/Test_definitions/qos-profiles-getQosProfile.feature
@@ -79,7 +79,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 401
-        And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+        And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
     @qos_profiles_getQosProfile_401.3_invalid_access_token

--- a/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
@@ -234,7 +234,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 401
-        And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+        And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
     @qos_profiles_retrieveQoSProfiles_401.3_invalid_access_token

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -341,7 +341,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 401
-        And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+        And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
     @quality_on_demand_createSession_401.3_invalid_access_token

--- a/code/Test_definitions/quality-on-demand-deleteSession.feature
+++ b/code/Test_definitions/quality-on-demand-deleteSession.feature
@@ -83,7 +83,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation deleteSession
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 401
-        And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+        And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
     @quality_on_demand_deleteSession_401.3_invalid_access_token

--- a/code/Test_definitions/quality-on-demand-extendQosSessionDuration.feature
+++ b/code/Test_definitions/quality-on-demand-extendQosSessionDuration.feature
@@ -127,7 +127,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation extendQosSessionDuration
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 401
-        And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+        And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
     @quality_on_demand_extendQosSessionDuration_401.3_invalid_access_token

--- a/code/Test_definitions/quality-on-demand-getSession.feature
+++ b/code/Test_definitions/quality-on-demand-getSession.feature
@@ -89,7 +89,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation getSession
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 401
-        And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+        And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
     @quality_on_demand_getSession_401.3_invalid_access_token

--- a/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
+++ b/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
@@ -216,7 +216,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation retrieveSessionsByDevice
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 401
-        And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+        And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
     @quality_on_demand_retrieveSessionsByDevice_401.3_invalid_access_token


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities are removing the `AUTHENTICATION_REQUIRED" error, leaving "UNAUTHENTICATED" as the only valid error code when the HTTP error code is 401

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # N/A

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Remove AUTHENTICATION_REQUIRED error
```

#### Additional documentation 
None