### PR TITLE
chore: add CHANGELOG.MD to CODEOWNERS for release management

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,3 +10,7 @@
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins
 /MAINTAINERS.MD @camaraproject/admins
+
+# The following line ensures that the release-management_reviewers team will automatically added as reviewers
+# if a pull requests is changing the CHANGELOG.MD (aka "release PR") and that such PRs can only be merged with an approval from a team member.
+/CHANGELOG.MD @camaraproject/release-management_reviewers


### PR DESCRIPTION
## CAMARA Project Admin Update
  
  This pull request adds the CHANGELOG.MD file to CODEOWNERS to ensure that:
  - The release-management_reviewers team is automatically added as reviewers for release PRs
  - Release PRs (those changing CHANGELOG.MD) require approval from the release management team
  
  **Changes:**
  - Added `/CHANGELOG.MD @camaraproject/release-management_reviewers` to CODEOWNERS
  
  **Commit Strategy:** Pull request (default strategy)
  
  🤖 Generated by project-admin workflow