### PR TITLE
Refine terminology in qos-provisioning API

### DIFF
--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.3
 info:
-  title: QoS Provisioning API
+  title: QoS Provisioning
   description: |
-    The Quality of Service (QoS) Provisioning API provides a programmable interface for developers to request the indefinite assignment of a specified QoS profile to all traffic being sent or received by a specified device.
+    The Quality of Service (QoS) Provisioning API provides a programmable interface for developers to request the indefinite assignment of a specified QoS profile to all traffic being sent or received by a specified device, indefinitely.
 
-    The association resulting from the QoS provisioning request is represented by a QoS provisioning record (or QoS provisioning for short) that includes information about the date of provisioning, the QoS profile assigned to a device, the provisioning status, etc., as well as a `provisioningId` that uniquely identifies this record for later use.
+    The association resulting from the QoS provisioning request is represented by a QoS assignment record (or QoS assignment for short) that includes information about the date of assignment, the QoS profile assigned to a device, the assignment status, etc., as well as an `assignmentId` that uniquely identifies this record for later use.
 
     Additionally, this API configures the network to apply the requested QoS profile to a specified device whenever the device is connected to the network, until the assignment is revoked.
 
@@ -14,18 +14,18 @@ info:
     Latency, throughput or priority requirements of the application mapped to relevant QoS profile values. The set of QoS Profiles that a network operator is offering may be retrieved via the `qos-profiles` API (cf. https://github.com/camaraproject/QualityOnDemand/) or will be agreed during the onboarding with the API service provider.
 
     * **Identifier for the device**:
-    At least one identifier for the device out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the network operator for the device, at the request time. After the QoS provisioning request is accepted, the device may get different IP addresses, but the assignment will still apply to the device that was identified during the request process. Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
+    At least one identifier for the device out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the network operator for the device, at the request time. After the QoS Provisioning request is accepted, the device may get different IP addresses, but the assignment will still apply to the device that was identified during the request process. Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Notification URL and token**:
-    API consumers may provide a callback URL (`sink`) on which notifications about all status change events (eg. provisioning termination) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message. If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint.
+    API consumers may provide a callback URL (`sink`) on which notifications about all status change events (eg. assignment termination) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message. If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint.
 
     # Resources and Operations overview
     The API defines four operations:
 
     - An operation to assign a QoS profile for a given device indefinitely.
-    - An operation to get the information about a specific QoS provisioning record, identified by its `provisioningId`.
-    - An operation to get the details of a QoS provisioning record for a given device.
-    - An operation to revoke the assignment of a QoS profile to a given device, identified by the `provisioningId`.
+    - An operation to get the information about a specific QoS assignment record, identified by its `assignmentId`.
+    - An operation to get the details of a QoS assignment record for a given device.
+    - An operation to revoke the assignment of a QoS profile to a given device, identified by the `assignmentId`.
 
     # Authorization and authentication
 
@@ -94,14 +94,14 @@ paths:
         - If the request includes the `sink` and `sinkCredential` properties, the client will receive a `status-changed` event with the outcome of the process. The event will be sent also for synchronous operations.
 
         **NOTES:**
-        - When the provisioning status becomes `UNAVAILABLE`, the QoS profile assignment is not immediately released, but will get deleted automatically, at earliest 360 seconds after.
+        - When the assignment status becomes `UNAVAILABLE`, the QoS profile assignment is not immediately released, but will get deleted automatically, at earliest 360 seconds after.
 
-        This behavior allows API consumers which are not receiving notification events but are polling, to get the QoS profile assignment status information. Before a client can attempt to create a new QoS profile assignment for the same device, they must release the previous provisioning resources with an explicit `delete` operation if not yet automatically deleted.
+        This behavior allows API consumers which are not receiving notification events but are polling, to get the QoS profile assignment status information. Before a client can attempt to create a new QoS profile assignment for the same device, they must release the previous assignment resources with an explicit `delete` operation if not yet automatically deleted.
         - The access token may be either 2-legged or 3-legged. See "Identifying the device from the access token" for further information
           - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
           - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.
 
-      operationId: triggerQosProvisioning
+      operationId: createQosAssignment
       parameters:
         - $ref: "#/components/parameters/x-correlator"
       requestBody:
@@ -109,18 +109,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TriggerProvisioning"
+              $ref: "#/components/schemas/CreateAssignment"
         required: true
       callbacks:
         notifications:
           "{$request.body#/sink}":
             post:
-              summary: Provisioning notifications callback
+              summary: Assignment notifications callback
               description: |
                 Important: this endpoint is to be implemented by the API consumer.
-                The QoS server will call this endpoint whenever any QoS provisioning change related event occurs.
-                Currently only `PROVISIONING_STATUS_CHANGED` event is defined.
-              operationId: postProvisioningNotification
+                The QoS server will call this endpoint whenever any QoS assignment change related event occurs.
+                Currently only `ASSIGNMENT_STATUS_CHANGED` event is defined.
+              operationId: postQosAssignmentNotification
               parameters:
                 - $ref: "#/components/parameters/x-correlator"
               requestBody:
@@ -130,8 +130,8 @@ paths:
                     schema:
                       $ref: "#/components/schemas/CloudEvent"
                     examples:
-                      PROVISIONING_STATUS_CHANGED_EXAMPLE:
-                        $ref: "#/components/examples/PROVISIONING_STATUS_CHANGED_EXAMPLE"
+                      ASSIGNMENT_STATUS_CHANGED_EXAMPLE:
+                        $ref: "#/components/examples/ASSIGNMENT_STATUS_CHANGED_EXAMPLE"
               responses:
                 "204":
                   description: Successful notification
@@ -153,16 +153,16 @@ paths:
                 - notificationsBearerAuth: []
       responses:
         "201":
-          description: Provisioning created
+          description: Assignment created
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProvisioningInfo"
+                $ref: "#/components/schemas/AssignmentInfo"
         "400":
-          $ref: "#/components/responses/TriggerProvisioning400"
+          $ref: "#/components/responses/CreateAssignment400"
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
@@ -170,20 +170,20 @@ paths:
         "404":
           $ref: "#/components/responses/GenericDevice404"
         "409":
-          $ref: "#/components/responses/ProvisioningConflict409"
+          $ref: "#/components/responses/AssignmentConflict409"
         "422":
           $ref: "#/components/responses/Generic422"
         "429":
           $ref: "#/components/responses/Generic429"
       security:
         - openId:
-            - "qos-provisioning:device-qos:create"
+            - "qos-assignment:qos-assignments:create"
 
-  /qos-assignments/{provisioningId}:
+  /qos-assignments/{assignmentId}:
     get:
       tags:
         - QoS Provisioning
-      summary: Get the QoS profile assignment information identified by a provisioning record ID
+      summary: Get the QoS profile assignment information identified by a assignment record ID
       description: |
         Querying for details about the QoS profile assignment
 
@@ -191,27 +191,27 @@ paths:
         - The access token may be either 2-legged or 3-legged.
         - If a 3-legged access token is used, the subject associated with the QoS profile assignment must also be associated with the access token.
         - The QoS profile assignment must have been created by the same API consumer given in the access token.
-      operationId: getQosProvisioningById
+      operationId: getQosAssignmentById
       parameters:
-        - $ref: "#/components/parameters/provisioningId"
+        - $ref: "#/components/parameters/assignmentId"
         - $ref: "#/components/parameters/x-correlator"
       responses:
         "200":
-          description: Returns information about certain provisioning
+          description: Returns information about certain assignment
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProvisioningInfo"
+                $ref: "#/components/schemas/AssignmentInfo"
               examples:
-                PROVISIONING_AVAILABLE:
-                  $ref: "#/components/examples/PROVISIONING_AVAILABLE"
-                PROVISIONING_UNAVAILABLE:
-                  $ref: "#/components/examples/PROVISIONING_UNAVAILABLE"
-                PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
-                  $ref: "#/components/examples/PROVISIONING_AVAILABLE_WITHOUT_DEVICE"
+                ASSIGNMENT_AVAILABLE:
+                  $ref: "#/components/examples/ASSIGNMENT_AVAILABLE"
+                ASSIGNMENT_UNAVAILABLE:
+                  $ref: "#/components/examples/ASSIGNMENT_UNAVAILABLE"
+                ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE:
+                  $ref: "#/components/examples/ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -224,16 +224,16 @@ paths:
           $ref: "#/components/responses/Generic429"
       security:
         - openId:
-            - "qos-provisioning:device-qos:read"
+            - "qos-provisioning:qos-assignments:read"
 
     delete:
       tags:
         - QoS Provisioning
-      summary: Revokes a QoS profile assignment identified by a provisioning record ID
+      summary: Revokes a QoS profile assignment identified by an assignment record ID
       description: |
-        Revokes the assignment of a QoS profile to a device performed by a previous provisioning operation.
+        Revokes the assignment of a QoS profile to a device performed by a previous assignment operation.
 
-        If the notification callback is provided and the provisioning status was `AVAILABLE`, when the process is completed, the API consumer will receive in addition to the response a `PROVISIONING_STATUS_CHANGED` event with
+        If the notification callback is provided and the assignment status was `AVAILABLE`, when the process is completed, the API consumer will receive in addition to the response a `ASSIGNMENT_STATUS_CHANGED` event with
         - `status` as `UNAVAILABLE` and
         - `statusInfo` as `DELETE_REQUESTED`
         There will be no notification event if the `status` was already `UNAVAILABLE`.
@@ -242,13 +242,13 @@ paths:
         - The access token may be either 2-legged or 3-legged.
         - If a 3-legged access token is used, the subject associated with the QoS profile assignment must also be associated with the access token.
         - The QoS profile assignment must have been created by the same API consumer given in the access token.
-      operationId: revokeQosProvisioning
+      operationId: revokeQosAssignment
       parameters:
-        - $ref: "#/components/parameters/provisioningId"
+        - $ref: "#/components/parameters/assignmentId"
         - $ref: "#/components/parameters/x-correlator"
       responses:
         "204":
-          description: Provisioning revoked
+          description: Assignment revoked
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"
@@ -260,7 +260,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProvisioningInfo"
+                $ref: "#/components/schemas/AssignmentInfo"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -273,15 +273,15 @@ paths:
           $ref: "#/components/responses/Generic429"
       security:
         - openId:
-            - "qos-provisioning:device-qos:delete"
+            - "qos-provisioning:qos-assignments:delete"
 
   /retrieve-qos-assignment:
     post:
       tags:
         - QoS Provisioning
-      summary: Returns the provisioning record details of the QoS profile assignment for a device
+      summary: Returns the assignment record details of the QoS profile assignment for a device
       description: |
-        Returns the details of the provisioning record for the assignment of a QoS profile to a device, if any.
+        Returns the details of the record for the assignment of a QoS profile to a device, if any.
 
         **NOTES:**
         - The access token may be either 2-legged or 3-legged. See "Identifying the device from the access token" for further information
@@ -291,15 +291,15 @@ paths:
         - If no QoS profile assignment is found for the device, an error response 404 is returned with code "NOT_FOUND".
         - This call uses the POST method instead of GET to comply with the [CAMARA Commonalities guidelines](https://github.com/camaraproject/Commonalities/blob/r2.3/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data) for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET.
 
-      operationId: getQosProvisioningByDevice
+      operationId: getQosAssignmentByDevice
       parameters:
         - $ref: "#/components/parameters/x-correlator"
       requestBody:
-        description: Parameters to retrieve a provisioning record by device
+        description: Parameters to retrieve a assignment record by device
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/RetrieveProvisioningByDevice"
+              $ref: "#/components/schemas/RetrieveAssignmentByDevice"
         required: true
       responses:
         "200":
@@ -311,12 +311,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProvisioningInfo"
+                $ref: "#/components/schemas/AssignmentInfo"
               examples:
-                PROVISIONING_AVAILABLE:
-                  $ref: "#/components/examples/PROVISIONING_AVAILABLE"
-                PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
-                  $ref: "#/components/examples/PROVISIONING_AVAILABLE_WITHOUT_DEVICE"
+                ASSIGNMENT_AVAILABLE:
+                  $ref: "#/components/examples/ASSIGNMENT_AVAILABLE"
+                ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE:
+                  $ref: "#/components/examples/ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -331,7 +331,7 @@ paths:
           $ref: "#/components/responses/Generic429"
       security:
         - openId:
-            - "qos-provisioning:device-qos:read-by-device"
+            - "qos-provisioning:qos-assignments:read-by-device"
 
 components:
   securitySchemes:
@@ -346,13 +346,13 @@ components:
       bearerFormat: "{$request.body#/sinkCredential.credentialType}"
 
   parameters:
-    provisioningId:
-      name: provisioningId
+    assignmentId:
+      name: assignmentId
       in: path
-      description: Identifier of the provisioning record for the QoS profile assignment, that was created by the `triggerQosProvisioning` operation
+      description: Identifier of the assignment record for the QoS profile assignment, that was created by the `createQosAssignment` operation
       required: true
       schema:
-        $ref: "#/components/schemas/ProvisioningId"
+        $ref: "#/components/schemas/AssignmentId"
 
     x-correlator:
       name: x-correlator
@@ -372,13 +372,13 @@ components:
         example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
 
   schemas:
-    ProvisioningId:
-      description: Identifier of the provisioning record for the QoS profile assignment, that was created by the `triggerQosProvisioning` operation
+    AssignmentId:
+      description: Identifier of the assignment record for the QoS profile assignment, that was created by the `createQosAssignment` operation
       type: string
       format: uuid
 
-    BaseProvisioningInfo:
-      description: Common attributes of the provisioning record for a QoS profile assignment
+    BaseAssignmentInfo:
+      description: Common attributes of the assignment record for a QoS profile assignment
       type: object
       properties:
         device:
@@ -395,18 +395,18 @@ components:
       required:
         - qosProfile
 
-    ProvisioningInfo:
+    AssignmentInfo:
       description: |
         Information about a QoS profile assignment returned in responses.
-        Optional device object only to be returned if provided in `triggerQosProvisioning`. If more than one type of device identifier was provided, only one identifier will be returned (at implementation choice and with the original value provided in assignQosProfile).
-        Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time the QoS profile assignment was triggered.
+        Optional device object only to be returned if provided in `createQosAssignment`. If more than one type of device identifier was provided, only one identifier will be returned (at implementation choice and with the original value provided in assignQosProfile).
+        Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time the QoS profile assignment was created.
 
       allOf:
-        - $ref: "#/components/schemas/BaseProvisioningInfo"
+        - $ref: "#/components/schemas/BaseAssignmentInfo"
         - type: object
           properties:
-            provisioningId:
-              $ref: "#/components/schemas/ProvisioningId"
+            assignmentId:
+              $ref: "#/components/schemas/AssignmentId"
             startedAt:
               description: Date and time when the QoS profile assignment became "AVAILABLE". Not to be returned when `status` is "REQUESTED". Format must follow RFC 3339 and must indicate time zone (UTC or local).
               type: string
@@ -417,15 +417,15 @@ components:
             statusInfo:
               $ref: "#/components/schemas/StatusInfo"
           required:
-            - provisioningId
+            - assignmentId
             - status
 
-    TriggerProvisioning:
+    CreateAssignment:
       description: Attributes to request a new QoS profile assignment
       allOf:
-        - $ref: "#/components/schemas/BaseProvisioningInfo"
+        - $ref: "#/components/schemas/BaseAssignmentInfo"
 
-    RetrieveProvisioningByDevice:
+    RetrieveAssignmentByDevice:
       description: Attributes to look for a QoS profile assignment
       type: object
       properties:
@@ -486,8 +486,8 @@ components:
               format: date-time
               description: |
                 REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired. Token expiration should occur
-                after the termination of the requested provisioning, allowing the client to be notified of any changes during the
-                provisioning's existence. If the token expires while the provisioning is still active, the client will stop receiving notifications.
+                after the termination of the requested assignment, allowing the client to be notified of any changes during the
+                assignment's existence. If the token expires while the assignment is still active, the client will stop receiving notifications.
                 If the access token is a JWT and registered "exp" (Expiration Time) claim is present, the two expiry times should match.
                 It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
                 Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)
@@ -611,11 +611,11 @@ components:
               type: object
               description: Event details depending on the event type
               required:
-                - provisioningId
+                - assignmentId
                 - qosStatus
               properties:
-                provisioningId:
-                  $ref: "#/components/schemas/ProvisioningId"
+                assignmentId:
+                  $ref: "#/components/schemas/AssignmentId"
                 status:
                   $ref: "#/components/schemas/StatusChanged"
                 statusInfo:
@@ -782,7 +782,7 @@ components:
                 code: OUT_OF_RANGE
                 message: Client specified an invalid range.
 
-    TriggerProvisioning400:
+    CreateAssignment400:
       description: Bad Request with additional errors for implicit notifications
       headers:
         x-correlator:
@@ -938,8 +938,8 @@ components:
                 code: IDENTIFIER_NOT_FOUND
                 message: Device identifier not found.
 
-    ProvisioningConflict409:
-      description: Provisioning conflict
+    AssignmentConflict409:
+      description: Assignment conflict
       headers:
         x-correlator:
           $ref: "#/components/headers/x-correlator"
@@ -957,7 +957,7 @@ components:
                     enum:
                       - CONFLICT
           examples:
-            PROVISIONING_409_CONFLICT:
+            ASSIGNMENT_409_CONFLICT:
               description: The requested provisioning process conflicts with an existing one
               value:
                 status: 409
@@ -1078,7 +1078,7 @@ components:
                 message: Rate limit reached.
 
   examples:
-    PROVISIONING_AVAILABLE:
+    ASSIGNMENT_AVAILABLE:
       summary: QoS provisioning status is available
       description: The QoS profile assignment has become available
       value:
@@ -1091,11 +1091,11 @@ components:
           accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
           accessTokenType: bearer
-        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         startedAt: "2024-05-12T17:32:01Z"
         status: AVAILABLE
 
-    PROVISIONING_UNAVAILABLE:
+    ASSIGNMENT_UNAVAILABLE:
       summary: QoS provisioning status is unavailable
       description: The QoS profile assignment could not be created or is not active anymore
       value:
@@ -1111,12 +1111,12 @@ components:
           accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
           accessTokenType: bearer
-        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         startedAt: "2024-05-12T17:32:01Z"
         status: UNAVAILABLE
         statusInfo: NETWORK_TERMINATED
 
-    PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
+    ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE:
       summary: QoS provisioning status is available but no device information is provided
       description: Device is optional in responses and must not be provided if it was not provided in the request
       value:
@@ -1127,20 +1127,20 @@ components:
           accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
           accessTokenType: bearer
-        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         startedAt: "2024-05-12T17:32:01Z"
         status: AVAILABLE
 
-    PROVISIONING_STATUS_CHANGED_EXAMPLE:
-      description: Provisioning status changed
+    ASSIGNMENT_STATUS_CHANGED_EXAMPLE:
+      description: Assignment status changed
       summary: Cloud event example for QoS provisioning status change to UNAVAILABLE due to NETWORK_TERMINATED
       value:
         id: 83a0d986-0866-4f38-b8c0-fc65bfcda452
-        source: https://api.example.com/qos-provisioning/v0.2/device-qos/123e4567-e89b-12d3-a456-426614174000
+        source: https://api.example.com/qos-provisioning/v0.4/qos-assignments/123e4567-e89b-12d3-a456-426614174000
         specversion: "1.0"
         type: org.camaraproject.qos-provisioning.v0.status-changed
         time: "2021-12-12T00:00:00Z"
         data:
-          provisioningId: 123e4567-e89b-12d3-a456-426614174000
+          assignmentId: 123e4567-e89b-12d3-a456-426614174000
           status: UNAVAILABLE
           statusInfo: NETWORK_TERMINATED

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: QoS Provisioning API
   description: |
-    The Quality of Service (QoS) Provisioning API provides a programmable interface for developers to request the assignment of a specific QoS profile with a device, indefinitely.
+    The Quality of Service (QoS) Provisioning API provides a programmable interface for developers to request the indefinite assignment of a specified QoS profile to all traffic being sent or received by a specified device.
 
     The association resulting from the QoS provisioning request is represented by a QoS provisioning record (or QoS provisioning for short) that includes information about the date of provisioning, the QoS profile assigned to a device, the provisioning status, etc., as well as a `provisioningId` that uniquely identifies this record for later use.
 

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -627,7 +627,7 @@ components:
       description: |
         Reason for the new `status`:
         * `NETWORK_TERMINATED` - Network terminated the QoS profile assignment
-        * `DELETE_REQUESTED`- User requested the deletion of the QoS profile assignment
+        * `DELETE_REQUESTED` - User requested the deletion of the QoS profile assignment
 
       type: string
       enum:

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -107,7 +107,7 @@ paths:
         **NOTES:**
         - When the assignment status becomes `UNAVAILABLE`, the QoS profile assignment is not immediately released, but will get deleted automatically, at earliest 360 seconds after.
 
-        This behavior allows API consumers which are not receiving notification events but are polling, to get the QoS profile assignment status information. Before a client can attempt to create a new QoS profile assignment for the same device, they must release the previous assignment resources with an explicit `delete` operation if not yet automatically deleted.
+        This behavior allows API consumers that are not receiving notification events but are polling, to get the QoS profile assignment status information. Before a client can attempt to create a new QoS profile assignment for the same device, they must release the previous assignment resources with an explicit `delete` operation if not yet automatically deleted.
         - The access token may be either 2-legged or 3-legged. See "Identifying the device from the access token" for further information
           - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
           - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -185,7 +185,7 @@ paths:
         - QoS Provisioning
       summary: Get the QoS profile assignment information identified by a provisioning record ID
       description: |
-        Querying for details about the QoS profile assignment 
+        Querying for details about the QoS profile assignment
 
         **NOTES:**
         - The access token may be either 2-legged or 3-legged.

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -372,7 +372,7 @@ components:
       description: Value for the x-correlator
       type: string
       pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
-      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"<<<<<<< qod-provisioning-review-terminology
+      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
 
     AssignmentId:
       description: Identifier of the assignment record for the QoS profile assignment, that was created by the `createQosAssignment` operation

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -198,7 +198,7 @@ paths:
   /qos-assignments/{assignmentId}:
     get:
       tags:
-        - QoS Provisioning
+        - QoS Assignment
       summary: Get the QoS profile assignment information identified by an assignment record ID
       description: |
         Querying for details about the QoS profile assignment

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: QoS Provisioning
   description: |
-    The Quality of Service (QoS) Provisioning API provides a programmable interface for developers to request the indefinite assignment of a specified QoS profile to all traffic being sent or received by a specified device, indefinitely.
+    The Quality of Service (QoS) Provisioning API provides a programmable interface for developers to request the indefinite assignment of a specified QoS profile to all traffic being sent or received by a specified device.
 
     The association resulting from the QoS provisioning request is represented by a QoS assignment record (or QoS assignment for short) that includes information about the date of assignment, the QoS profile assigned to a device, the assignment status, etc., as well as an `assignmentId` that uniquely identifies this record for later use.
 
@@ -177,13 +177,13 @@ paths:
           $ref: "#/components/responses/Generic429"
       security:
         - openId:
-            - "qos-assignment:qos-assignments:create"
+            - "qos-provisioning:qos-assignments:create"
 
   /qos-assignments/{assignmentId}:
     get:
       tags:
         - QoS Provisioning
-      summary: Get the QoS profile assignment information identified by a assignment record ID
+      summary: Get the QoS profile assignment information identified by an assignment record ID
       description: |
         Querying for details about the QoS profile assignment
 
@@ -295,7 +295,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/x-correlator"
       requestBody:
-        description: Parameters to retrieve a assignment record by device
+        description: Parameters to retrieve an assignment record by device
         content:
           application/json:
             schema:

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -244,7 +244,7 @@ paths:
 
     delete:
       tags:
-        - QoS Provisioning
+        - QoS Assignment
       summary: Revokes a QoS profile assignment identified by an assignment record ID
       description: |
         Revokes the assignment of a QoS profile to a device performed by a previous assignment operation.

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -1,12 +1,12 @@
 openapi: 3.0.3
 info:
-  title: QoD Provisioning API
+  title: QoS Provisioning API
   description: |
-    The Quality-on-Demand (QoD) Provisioning API provides a programmable interface for developers to request the association of a specific QoS profile with a device, indefinitely.
+    The Quality of Service (QoS) Provisioning API provides a programmable interface for developers to request the assignment of a specific QoS profile with a device, indefinitely.
 
-    The association resulting from the QoD provisioning request is represented by a QoD provisioning record (or QoD provisioning for short) that includes information about the date of provisioning, the QoS profile, the provisioning status, etc., as well as a provisioningId that uniquely identifies this record for later use.
+    The association resulting from the QoS provisioning request is represented by a QoS provisioning record (or QoS provisioning for short) that includes information about the date of provisioning, the QoS profile assigned to a device, the provisioning status, etc., as well as a `provisioningId` that uniquely identifies this record for later use.
 
-    Additionally, this API configures the network to apply the requested QoS profile to a specified device whenever the device is connected to the network, until the provisioning is revoked.
+    Additionally, this API configures the network to apply the requested QoS profile to a specified device whenever the device is connected to the network, until the assignment is revoked.
 
     # Relevant terms and definitions
 
@@ -14,7 +14,7 @@ info:
     Latency, throughput or priority requirements of the application mapped to relevant QoS profile values. The set of QoS Profiles that a network operator is offering may be retrieved via the `qos-profiles` API (cf. https://github.com/camaraproject/QualityOnDemand/) or will be agreed during the onboarding with the API service provider.
 
     * **Identifier for the device**:
-    At least one identifier for the device out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the network operator for the device, at the request time. After the provisioning request is accepted, the device may get different IP addresses, but the provisioning will still apply to the device that was identified during the request process. Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
+    At least one identifier for the device out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the network operator for the device, at the request time. After the QoS provisioning request is accepted, the device may get different IP addresses, but the assignment will still apply to the device that was identified during the request process. Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Notification URL and token**:
     API consumers may provide a callback URL (`sink`) on which notifications about all status change events (eg. provisioning termination) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message. If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint.
@@ -22,10 +22,10 @@ info:
     # Resources and Operations overview
     The API defines four operations:
 
-    - An operation to set up a new QoD provisioning for a given device.
-    - An operation to get the information about a specific QoD provisioning, identified by its `provisioningId`.
-    - An operation to get the QoD provisioning for a given device.
-    - An operation to revoke a QoD provisioning, identified by its `provisioningId`.
+    - An operation to assign a QoS profile for a given device indefinitely.
+    - An operation to get the information about a specific QoS provisioning record, identified by its `provisioningId`.
+    - An operation to get the details of a QoS provisioning record for a given device.
+    - An operation to revoke the assignment of a QoS profile to a given device, identified by the `provisioningId`.
 
     # Authorization and authentication
 
@@ -51,7 +51,7 @@ info:
 
     # Multi-SIM scenario handling
 
-    In multi-SIM scenarios where more than one mobile device is associated with a phone number (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device to which the QoD provisioning should apply from that phone number. If the phone number is used as the device identifier when provisioning in a multi-SIM scenario, the API may respond with an error, apply the provisioning to all devices in the multi-SIM group, or apply the provisioning to a single device in the multi-SIM group which may not be the intended device.
+    In multi-SIM scenarios where more than one mobile device is associated with a phone number (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device to which the QoS profile should apply from that phone number. If the phone number is used as the device identifier when provisioning a QoS profile in a multi-SIM scenario, the API may respond with an error, apply the QoS profile to all devices in the multi-SIM group, or apply the QoS profile to a single device in the multi-SIM group which may not be the intended device.
 
     Possible solutions in such a scenario include:
     - Using the authorisation code flow to obtain an access token, which will automatically identify the intended device
@@ -69,44 +69,43 @@ externalDocs:
   url: https://github.com/camaraproject/QualityOnDemand
 
 servers:
-  - url: "{apiRoot}/qod-provisioning/vwip"
+  - url: "{apiRoot}/qos-provisioning/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091
         description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 tags:
-  - name: QoD Provisioning
-    description: Manage the permanent provisioning of QoD
+  - name: QoS Provisioning
+    description: Manage the permanent assignment of a QoS profile to a device
 
 paths:
-  /device-qos:
+  /qos-assignments:
     post:
       tags:
-        - QoD Provisioning
-      summary: Triggers a new provisioning of QoS for a device
+        - QoS Provisioning
+      summary: Triggers the provisioning process for the assignment of a QoS profile to a device
       description: |
-        Triggers the provisioning in the operator's environment to associate a given QoS profile with a given device.
+        Initiates the assignment of a specific QoS profile to a given device in the operator's environment.
 
+        - If the QoS profile assignment is completed synchronously, the response will be 201 with `status` = `AVAILABLE`.
+        - If the QoS profile assignment request is accepted but not yet completed, the response will be 201 with `status` = `REQUESTED`.
+        - If the operator determines synchronously that the QoS profile assignment request cannot be fulfilled, the response will be 201 with `status` = `UNAVAILABLE`.
 
-        - If the provisioning is completed synchronously, the response will be 201 with `status` = `AVAILABLE`.
-        - If the provisioning request is accepted but not yet completed, the response will be 201 with `status` = `REQUESTED`.
-        - If the operator determines synchronously that the provisioning request cannot be fulfilled, the response will be 201 with `status` = `UNAVAILABLE`.
-
-        - If the request includes  the `sink` and `sinkCredential` properties, the client will receive a `status-changed` event with the outcome of the process. The event will be sent also for synchronous operations.
+        - If the request includes the `sink` and `sinkCredential` properties, the client will receive a `status-changed` event with the outcome of the process. The event will be sent also for synchronous operations.
 
         **NOTES:**
-        - When the provisioning status becomes `UNAVAILABLE`, the QoD provisioning resource is not immediately released, but will get deleted automatically, at earliest 360 seconds after.
+        - When the provisioning status becomes `UNAVAILABLE`, the QoS profile assignment is not immediately released, but will get deleted automatically, at earliest 360 seconds after.
 
-        This behavior allows API consumers which are not receiving notification events but are polling, to get the provisioning status information. Before a client can attempt to create a new QoD provisioning for the same device, they must release the provisioning resources with an explicit `delete` operation if not yet automatically deleted.
+        This behavior allows API consumers which are not receiving notification events but are polling, to get the QoS profile assignment status information. Before a client can attempt to create a new QoS profile assignment for the same device, they must release the previous provisioning resources with an explicit `delete` operation if not yet automatically deleted.
         - The access token may be either 2-legged or 3-legged. See "Identifying the device from the access token" for further information
           - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
           - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.
 
-      operationId: triggerProvisioning
+      operationId: triggerQosProvisioning
       parameters:
         - $ref: "#/components/parameters/x-correlator"
       requestBody:
-        description: Parameters to trigger a new provisioning
+        description: Parameters to assign a QoS profile to a device
         content:
           application/json:
             schema:
@@ -119,7 +118,7 @@ paths:
               summary: Provisioning notifications callback
               description: |
                 Important: this endpoint is to be implemented by the API consumer.
-                The QoD server will call this endpoint whenever any QoD provisioning change related event occurs.
+                The QoS server will call this endpoint whenever any QoS provisioning change related event occurs.
                 Currently only `PROVISIONING_STATUS_CHANGED` event is defined.
               operationId: postProvisioningNotification
               parameters:
@@ -178,21 +177,21 @@ paths:
           $ref: "#/components/responses/Generic429"
       security:
         - openId:
-            - "qod-provisioning:device-qos:create"
+            - "qos-provisioning:device-qos:create"
 
-  /device-qos/{provisioningId}:
+  /qos-assignments/{provisioningId}:
     get:
       tags:
-        - QoD Provisioning
-      summary: Get QoD provisioning information
+        - QoS Provisioning
+      summary: Get the QoS profile assignment information identified by a provisioning record ID
       description: |
-        Querying for QoD provisioning resource information details
+        Querying for details about the QoS profile assignment 
 
         **NOTES:**
         - The access token may be either 2-legged or 3-legged.
-        - If a 3-legged access token is used, the subject associated with the QoD provisioning must also be associated with the access token.
-        - The QoD provisioning must have been created by the same API consumer given in the access token.
-      operationId: getProvisioningById
+        - If a 3-legged access token is used, the subject associated with the QoS profile assignment must also be associated with the access token.
+        - The QoS profile assignment must have been created by the same API consumer given in the access token.
+      operationId: getQosProvisioningById
       parameters:
         - $ref: "#/components/parameters/provisioningId"
         - $ref: "#/components/parameters/x-correlator"
@@ -225,15 +224,14 @@ paths:
           $ref: "#/components/responses/Generic429"
       security:
         - openId:
-            - "qod-provisioning:device-qos:read"
+            - "qos-provisioning:device-qos:read"
 
     delete:
       tags:
-        - QoD Provisioning
-      summary: Revokes a QoD provisioning
+        - QoS Provisioning
+      summary: Revokes a QoS profile assignment identified by a provisioning record ID
       description: |
-        Revokes the association of a QoS profile with the device performed by a previous provisioning.
-
+        Revokes the assignment of a QoS profile to a device performed by a previous provisioning operation.
 
         If the notification callback is provided and the provisioning status was `AVAILABLE`, when the process is completed, the API consumer will receive in addition to the response a `PROVISIONING_STATUS_CHANGED` event with
         - `status` as `UNAVAILABLE` and
@@ -242,9 +240,9 @@ paths:
 
         **NOTES:**
         - The access token may be either 2-legged or 3-legged.
-        - If a 3-legged access token is used, the subject associated with the QoD provisioning must also be associated with the access token.
-        - The QoD provisioning must have been created by the same API consumer given in the access token.
-      operationId: revokeProvisioning
+        - If a 3-legged access token is used, the subject associated with the QoS profile assignment must also be associated with the access token.
+        - The QoS profile assignment must have been created by the same API consumer given in the access token.
+      operationId: revokeQosProvisioning
       parameters:
         - $ref: "#/components/parameters/provisioningId"
         - $ref: "#/components/parameters/x-correlator"
@@ -275,29 +273,29 @@ paths:
           $ref: "#/components/responses/Generic429"
       security:
         - openId:
-            - "qod-provisioning:device-qos:delete"
+            - "qos-provisioning:device-qos:delete"
 
-  /retrieve-device-qos:
+  /retrieve-qos-assignment:
     post:
       tags:
-        - QoD Provisioning
-      summary: Gets the QoD provisioning for a device
+        - QoS Provisioning
+      summary: Returns the provisioning record details of the QoS profile assignment for a device
       description: |
-        Retrieves the QoD provisioning for a device.
+        Returns the details of the provisioning record for the assignment of a QoS profile to a device, if any.
 
         **NOTES:**
         - The access token may be either 2-legged or 3-legged. See "Identifying the device from the access token" for further information
           - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
           - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.
-        - The QoD provisioning must have been created by the same API consumer given in the access token.
-        - If no provisioning is found for the device, an error response 404 is returned with code "NOT_FOUND".
+        - The QoS profile assignment must have been created by the same API consumer given in the access token.
+        - If no QoS profile assignment is found for the device, an error response 404 is returned with code "NOT_FOUND".
         - This call uses the POST method instead of GET to comply with the [CAMARA Commonalities guidelines](https://github.com/camaraproject/Commonalities/blob/r2.3/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data) for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET.
 
-      operationId: retrieveProvisioningByDevice
+      operationId: getQosProvisioningByDevice
       parameters:
         - $ref: "#/components/parameters/x-correlator"
       requestBody:
-        description: Parameters to retrieve a provisioning by device
+        description: Parameters to retrieve a provisioning record by device
         content:
           application/json:
             schema:
@@ -305,7 +303,7 @@ paths:
         required: true
       responses:
         "200":
-          description: Returns information about the QoD provisioning for the device.
+          description: Returns information about the QoS profile assignment for the device.
 
           headers:
             x-correlator:
@@ -333,7 +331,7 @@ paths:
           $ref: "#/components/responses/Generic429"
       security:
         - openId:
-            - "qod-provisioning:device-qos:read-by-device"
+            - "qos-provisioning:device-qos:read-by-device"
 
 components:
   securitySchemes:
@@ -351,7 +349,7 @@ components:
     provisioningId:
       name: provisioningId
       in: path
-      description: Provisioning ID that was obtained from the createProvision operation
+      description: Identifier of the provisioning record for the QoS profile assignment, that was created by the `triggerQosProvisioning` operation
       required: true
       schema:
         $ref: "#/components/schemas/ProvisioningId"
@@ -375,12 +373,12 @@ components:
 
   schemas:
     ProvisioningId:
-      description: Provisioning Identifier in UUID format
+      description: Identifier of the provisioning record for the QoS profile assignment, that was created by the `triggerQosProvisioning` operation
       type: string
       format: uuid
 
     BaseProvisioningInfo:
-      description: Common attributes of a QoD provisioning
+      description: Common attributes of the provisioning record for a QoS profile assignment
       type: object
       properties:
         device:
@@ -399,9 +397,9 @@ components:
 
     ProvisioningInfo:
       description: |
-        Provisioning related information returned in responses.
-        Optional device object only to be returned if provided in triggerProvisioning. If more than one type of device identifier was provided, only one identifier will be returned (at implementation choice and with the original value provided in triggerProvisioning).
-        Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time the QoD provisioning was triggered.
+        Information about a QoS profile assignment returned in responses.
+        Optional device object only to be returned if provided in `triggerQosProvisioning`. If more than one type of device identifier was provided, only one identifier will be returned (at implementation choice and with the original value provided in assignQosProfile).
+        Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time the QoS profile assignment was triggered.
 
       allOf:
         - $ref: "#/components/schemas/BaseProvisioningInfo"
@@ -410,7 +408,7 @@ components:
             provisioningId:
               $ref: "#/components/schemas/ProvisioningId"
             startedAt:
-              description: Date and time when the provisioning became "AVAILABLE". Not to be returned when `status` is "REQUESTED". Format must follow RFC 3339 and must indicate time zone (UTC or local).
+              description: Date and time when the QoS profile assignment became "AVAILABLE". Not to be returned when `status` is "REQUESTED". Format must follow RFC 3339 and must indicate time zone (UTC or local).
               type: string
               format: date-time
               example: "2024-06-01T12:00:00Z"
@@ -423,12 +421,12 @@ components:
             - status
 
     TriggerProvisioning:
-      description: Attributes to request a new QoD provisioning
+      description: Attributes to request a new QoS profile assignment
       allOf:
         - $ref: "#/components/schemas/BaseProvisioningInfo"
 
     RetrieveProvisioningByDevice:
-      description: Attributes to look for QoD provisioning
+      description: Attributes to look for a QoS profile assignment
       type: object
       properties:
         device:
@@ -579,7 +577,7 @@ components:
           description: The type of the event.
           type: string
           enum:
-            - "org.camaraproject.qod-provisioning.v0.status-changed"
+            - "org.camaraproject.qos-provisioning.v0.status-changed"
         specversion:
           description: Version of the specification to which this event conforms (must be 1.0 if it conforms to cloudevents 1.0.2 version)
           type: string
@@ -601,10 +599,10 @@ components:
       discriminator:
         propertyName: "type"
         mapping:
-          org.camaraproject.qod-provisioning.v0.status-changed: "#/components/schemas/EventStatusChanged"
+          org.camaraproject.qos-provisioning.v0.status-changed: "#/components/schemas/EventStatusChanged"
 
     EventStatusChanged:
-      description: Event to notify a QoD provisioning status change
+      description: Event to notify a QoS provisioning status change
       allOf:
         - $ref: "#/components/schemas/CloudEvent"
         - type: object
@@ -628,8 +626,8 @@ components:
     StatusInfo:
       description: |
         Reason for the new `status`:
-        * `NETWORK_TERMINATED` - Network terminated the QoD provisioning
-        * `DELETE_REQUESTED`- User requested the deletion of the QoD provisioning
+        * `NETWORK_TERMINATED` - Network terminated the QoS profile assignment
+        * `DELETE_REQUESTED`- User requested the deletion of the QoS profile assignment
 
       type: string
       enum:
@@ -713,10 +711,10 @@ components:
 
     Status:
       description: |
-        The current status of the requested QoD provisioning. The status can be one of the following:
-        * `REQUESTED` - QoD provisioning has been requested but is still being processed.
-        * `AVAILABLE` - The requested QoS profile has been provisioned to the device, and is active.
-        * `UNAVAILABLE` - The QoD provisioning request has been processed but is not active. `statusInfo` may provide additional information about the reason for the unavailability.
+        The current status of the requested QoS profile assignment. The status can be one of the following:
+        * `REQUESTED` - QoS profile assignment has been requested but is still being processed.
+        * `AVAILABLE` - The requested QoS profile has been assigned to the device, and is active.
+        * `UNAVAILABLE` - The QoS profile assignment request has been processed but is not active. `statusInfo` may provide additional information about the reason for the unavailability.
       enum:
         - REQUESTED
         - AVAILABLE
@@ -724,9 +722,9 @@ components:
 
     StatusChanged:
       description: |
-        The current status of a requested or previously available QoD provisioning. Applicable values in the event are:
-        *  `AVAILABLE` - The requested QoS profile has been provisioned to the device, and is active.
-        *  `UNAVAILABLE` - A requested or previously available QoD provisioning is now unavailable. `statusInfo` may provide additional information about the reason for the unavailability.
+        The current status of a requested or previously available QoS profile assignment. Applicable values in the event are:
+        *  `AVAILABLE` - The requested QoS profile has been assigned to the device, and is active.
+        *  `UNAVAILABLE` - A requested or previously available QoS profile assignment is now unavailable. `statusInfo` may provide additional information about the reason for the unavailability.
       type: string
       enum:
         - AVAILABLE
@@ -960,7 +958,7 @@ components:
                       - CONFLICT
           examples:
             PROVISIONING_409_CONFLICT:
-              description: The requested provisioning conflicts with an existing one
+              description: The requested provisioning process conflicts with an existing one
               value:
                 status: 409
                 code: CONFLICT
@@ -1081,8 +1079,8 @@ components:
 
   examples:
     PROVISIONING_AVAILABLE:
-      summary: QoD provisioning status is available
-      description: The provisioning has become available
+      summary: QoS provisioning status is available
+      description: The QoS profile assignment has become available
       value:
         device:
           phoneNumber: "+123456789"
@@ -1098,8 +1096,8 @@ components:
         status: AVAILABLE
 
     PROVISIONING_UNAVAILABLE:
-      summary: QoD provisioning status is unavailable
-      description: The provisioning could not be created or is not active anymore
+      summary: QoS provisioning status is unavailable
+      description: The QoS profile assignment could not be created or is not active anymore
       value:
         duration: 86400
         device:
@@ -1119,7 +1117,7 @@ components:
         statusInfo: NETWORK_TERMINATED
 
     PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
-      summary: QoD provisioning status is available but no device information is provided
+      summary: QoS provisioning status is available but no device information is provided
       description: Device is optional in responses and must not be provided if it was not provided in the request
       value:
         qosProfile: QOS_M
@@ -1135,12 +1133,12 @@ components:
 
     PROVISIONING_STATUS_CHANGED_EXAMPLE:
       description: Provisioning status changed
-      summary: Cloud event example for QoD provisioning status change to UNAVAILABLE due to NETWORK_TERMINATED
+      summary: Cloud event example for QoS provisioning status change to UNAVAILABLE due to NETWORK_TERMINATED
       value:
         id: 83a0d986-0866-4f38-b8c0-fc65bfcda452
-        source: https://api.example.com/qod-provisioning/v0.2/device-qos/123e4567-e89b-12d3-a456-426614174000
+        source: https://api.example.com/qos-provisioning/v0.2/device-qos/123e4567-e89b-12d3-a456-426614174000
         specversion: "1.0"
-        type: org.camaraproject.qod-provisioning.v0.status-changed
+        type: org.camaraproject.qos-provisioning.v0.status-changed
         time: "2021-12-12T00:00:00Z"
         data:
           provisioningId: 123e4567-e89b-12d3-a456-426614174000

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -86,7 +86,7 @@ servers:
         default: http://localhost:9091
         description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 tags:
-  - name: QoS Provisioning
+  - name: QoS Assignment
     description: Manage the permanent assignment of a QoS profile to a device
 
 paths:

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -85,7 +85,7 @@ paths:
         - QoS Provisioning
       summary: Triggers the provisioning process for the assignment of a QoS profile to a device
       description: |
-        Initiates the assignment of a specific QoS profile to a given device in the operator's environment.
+        Initiates the assignment of a specific QoS profile to a given device when connected to the operator's network.
 
         - If the QoS profile assignment is completed synchronously, the response will be 201 with `status` = `AVAILABLE`.
         - If the QoS profile assignment request is accepted but not yet completed, the response will be 201 with `status` = `REQUESTED`.

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -93,7 +93,7 @@ paths:
   /qos-assignments:
     post:
       tags:
-        - QoS Provisioning
+        - QoS Assignment
       summary: Triggers the provisioning process for the assignment of a QoS profile to a device
       description: |
         Initiates the assignment of a specific QoS profile to a given device when connected to the operator's network.

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -54,7 +54,7 @@ info:
 
     # Multi-SIM scenario handling
 
-    In multi-SIM scenarios where more than one mobile device is associated with a phone number (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device to which the QoS profile should apply from that phone number. If the phone number is used as the device identifier when provisioning a QoS profile in a multi-SIM scenario, the API may respond with an error, apply the QoS profile to all devices in the multi-SIM group, or apply the QoS profile to a single device in the multi-SIM group which may not be the intended device.
+    In multi-SIM scenarios where more than one mobile device is associated with a phone number (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device to which the QoS profile should apply from that phone number. If the phone number is used as the device identifier when assigning a QoS profile in a multi-SIM scenario, the API may respond with an error, apply the QoS profile to all devices in the multi-SIM group, or apply the QoS profile to a single device in the multi-SIM group which may not be the intended device.
 
     Possible solutions in such a scenario include:
     - Using the authorisation code flow to obtain an access token, which will automatically identify the intended device

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -294,7 +294,7 @@ paths:
   /retrieve-qos-assignment:
     post:
       tags:
-        - QoS Provisioning
+        - QoS Assignment
       summary: Returns the assignment record details of the QoS profile assignment for a device
       description: |
         Returns the details of the record for the assignment of a QoS profile to a device, if any.

--- a/code/Test_definitions/qod-provisioning-getProvisioningById.feature
+++ b/code/Test_definitions/qod-provisioning-getProvisioningById.feature
@@ -1,62 +1,62 @@
-Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
+Feature: CAMARA QoD Provisioning API, vwip - Operation getQosAssignmentById
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
     # * apiRoot: API root of the server URL
     #
     # Testing assets:
-    # * The provisioningId of an existing QoD Provisioning, and the request properties used for createProvisioning
+    # * The assignmentId of an existing QoS assignment, and the request properties used for createQosAssignment
     #
-    # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml
+    # References to OAS spec schemas refer to schemas specified in qos-provisioning.yaml
 
 
-    Background: Common getProvisioningById setup
+    Background: Common getQosAssignmentById setup
         Given an environment at "apiRoot"
-        And the resource "/qod-provisioning/vwip/device-qos/{provisioningId}"                                                              |
-        # Unless indicated otherwise the QoD provisioning must be created by the same API client given in the access token
-        And the header "Authorization" is set to a valid access token granted to the same client that created the QoD provisioning
+        And the resource "/qos-provisioning/vwip/qos-assignments/{assignmentId}"                                                              |
+        # Unless indicated otherwise the QoS assignment must be created by the same API client given in the access token
+        And the header "Authorization" is set to a valid access token granted to the same client that created the QoS assignment
         And the header "x-correlator" is set to a UUID value
-        And the path parameter "provisioningId" is set by default to an existing QoD provisioning ID
+        And the path parameter "assignmentId" is set by default to an existing QoS assignment ID
 
     # Success scenarios
 
-    @qod_provisioning_getProvisioningById_01_get_existing_qod_provisioning
-    Scenario: Get an existing QoD Provisioning by provisioningId
-        Given an existing QoD provisioning created by operation createProvisioning
-        And the path parameter "provisioningId" is set to the value for that QoD provisioning
-        When the request "getProvisioningById" is sent
+    @qos_provisioning_getQosAssignmentById_01_get_existing_qos_assignment
+    Scenario: Get an existing QoS assignment by assignmentId
+        Given an existing QoS assignment created by operation createQosAssignment
+        And the path parameter "assignmentId" is set to the value for that QoS assignment
+        When the request "getQosAssignmentById" is sent
         Then the response status code is 200
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         # The response has to comply with the generic response schema which is part of the spec
-        And the response body complies with the OAS schema at "/components/schemas/ProvisioningInfo"
+        And the response body complies with the OAS schema at "/components/schemas/AssignmentInfo"
         # Additionally any success response has to comply with some constraints beyond the schema compliance
-        And the response property "$.device" exists only if provided for createProvisioning and with the same value
-        And the response property "$.qosProfile" has the value provided for createProvisioning
-        And the response property "$.sink" exists only if provided for createProvisioning and with the same value
+        And the response property "$.device" exists only if provided for createQosAssignment and with the same value
+        And the response property "$.qosProfile" has the value provided for createQosAssignment
+        And the response property "$.sink" exists only if provided for createQosAssignment and with the same value
         # sinkCredentials not explicitly mentioned to be returned if present, as this is debatable for security concerns
         And the response property "$.startedAt" exists only if "$.status" is not "REQUESTED" and the value is in the past
         And the response property "$.statusInfo" exists only if "$.status" is "UNAVAILABLE"
 
-    @qod_provisioning_getProvisioningById_02_get_recent_unavailable
-    Scenario: Provisioning becoming "UNAVAILABLE" is not released for at least 360 seconds
-        Given an existing QoD provisioning deleted in the last 360 seconds
-        And the path parameter "provisioningId" is set to the value for that QoD provisioning
-        When the request "getProvisioningById" is sent
+    @qos_provisioning_getQosAssignmentById_02_get_recent_unavailable
+    Scenario: QoS assignment becoming "UNAVAILABLE" is not released for at least 360 seconds
+        Given an existing QoS assignment deleted in the last 360 seconds
+        And the path parameter "assignmentId" is set to the value for that QoS assignment
+        When the request "getQosAssignmentById" is sent
         Then the response status code is 200
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
-        And the response body complies with the OAS schema at "/components/schemas/ProvisioningInfo"
+        And the response body complies with the OAS schema at "/components/schemas/AssignmentInfo"
         And the response property "$.status" is "UNAVAILABLE"
 
     # Errors 400
 
-    # 400 errors are not expected for this operation unless the implementation validates the format of provisioningId
+    # 400 errors are not expected for this operation unless the implementation validates the format of assignmentId
     # 404 NOT_FOUND is an alternative if path parameter format is not validated
-    @qod_provisioning_getProvisioningById_400.1_invalid_id
+    @qos_provisioning_getQosAssignmentById_400.1_invalid_id
     Scenario: Invalid Argument. Generic Syntax Exception
-        Given the path parameter "provisioningId" has not a UUID format
-        When the request "getProvisioningById" is sent
+        Given the path parameter "assignmentId" has not a UUID format
+        When the request "getQosAssignmentById" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -66,10 +66,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
 
     # Generic 401 errors
 
-    @qod_provisioning_getProvisioningById_401.1_no_authorization_header
+    @qos_provisioning_getQosAssignmentById_401.1_no_authorization_header
     Scenario: No Authorization header
         Given the header "Authorization" is not sent
-        When the request "getProvisioningById" is sent
+        When the request "getQosAssignmentById" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -78,10 +78,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
         And the response property "$.message" contains a user friendly text
 
     # In this case both codes could make sense depending on whether the access token can be refreshed or not
-    @qod_provisioning_getProvisioningById_401.2_expired_access_token
+    @qos_provisioning_getQosAssignmentById_401.2_expired_access_token
     Scenario: Expired access token
         Given the header "Authorization" is set to an expired access token
-        When the request "getProvisioningById" is sent
+        When the request "getQosAssignmentById" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -89,10 +89,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
         And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_getProvisioningById_401.3_invalid_access_token
+    @qos_provisioning_getQosAssignmentById_401.3_invalid_access_token
     Scenario: Invalid access token
         Given the header "Authorization" is set to an invalid access token
-        When the request "getProvisioningById" is sent
+        When the request "getQosAssignmentById" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -102,10 +102,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
 
     # Errors 403
 
-    @qod_provisioning_getProvisioningById_403.1_missing_access_token_scope
+    @qos_provisioning_getQosAssignmentById_403.1_missing_access_token_scope
     Scenario: Missing access token scope
-        Given the header "Authorization" is set to an access token that does not include scope qod-provisioning:device-qos:read
-        When the request "getProvisioningById" is sent
+        Given the header "Authorization" is set to an access token that does not include scope qos-provisioning:qos-assignments:read
+        When the request "getQosAssignmentById" is sent
         Then the response status code is 403
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -113,11 +113,11 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
         And the response property "$.code" is "PERMISSION_DENIED"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_getProvisioningById_403.2_different_client_id
-    Scenario: QoD provisioning not created by the API client given in the access token
+    @qos_provisioning_getQosAssignmentById_403.2_different_client_id
+    Scenario: QoS assignment not created by the API client given in the access token
         # To test this, a token have to be obtained by a different client
-        Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoD provisioning
-        When the request "getProvisioningById" is sent
+        Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoS assignment
+        When the request "getQosAssignmentById" is sent
         Then the response status code is 403
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -127,10 +127,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getProvisioningById
 
     # Errors 404
 
-    @qod_provisioning_getProvisioningById_404.1_not_found
-    Scenario: provisioningId of a no existing QoD provisioning
-        Given the path parameter "provisioningId" is set to a random UUID
-        When the request "getProvisioningById" is sent
+    @qos_provisioning_getQosAssignmentById_404.1_not_found
+    Scenario: assignmentId of a no existing QoS assignment
+        Given the path parameter "assignmentId" is set to a random UUID
+        When the request "getQosAssignmentById" is sent
         Then the response status code is 404
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/qod-provisioning-getProvisioningById.feature
+++ b/code/Test_definitions/qod-provisioning-getProvisioningById.feature
@@ -34,7 +34,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation getQosAssignmentById
         And the response property "$.device" exists only if provided for createQosAssignment and with the same value
         And the response property "$.qosProfile" has the value provided for createQosAssignment
         And the response property "$.sink" exists only if provided for createQosAssignment and with the same value
-        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatable for security concerns
+        # sinkCredential not explicitly mentioned to be returned if present, as this is debatable for security concerns
         And the response property "$.startedAt" exists only if "$.status" is not "REQUESTED" and the value is in the past
         And the response property "$.statusInfo" exists only if "$.status" is "UNAVAILABLE"
 

--- a/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
+++ b/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
@@ -16,7 +16,7 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentByDevice
 
     Background: Common getQosAssignmentByDevice setup
         Given an environment at "apiRoot"
-        And the resource "/qos-provisioning/vwip/retrieve-qos-assignments"                                                              |
+        And the resource "/qos-provisioning/vwip/retrieve-qos-assignment"                                                              |
         And the header "Content-Type" is set to "application/json"
         # Unless indicated otherwise the QoS assignment must be created by the same API client given in the access token
         And the header "Authorization" is set to a valid access token granted to the same client that created the QoS assignment
@@ -37,7 +37,7 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentByDevice
         And the response property "$.device" exists only if provided for createQosAssignment and with the same value
         And the response property "$.qosProfile" has the value provided for createQosAssignment
         And the response property "$.sink" exists only if provided for createQosAssignment and with the same value
-        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatable for security concerns
+        # sinkCredential not explicitly mentioned to be returned if present, as this is debatable for security concerns
         And the response property "$.startedAt" exists only if "$.status" is "AVAILABLE" and the value is in the past
         And the response property "$.statusInfo" exists only if "$.status" is "UNAVAILABLE"
 
@@ -66,11 +66,11 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentByDevice
         And the response property "$.message" contains a user friendly text
         
         Examples:
-            | device_identifier          | oas_spec_schema                             |
-            | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-            | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
-            | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
-            | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
+            | device_identifier                | oas_spec_schema                             |
+            | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
+            | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+            | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
+            | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
   
     # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.
@@ -148,7 +148,7 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentByDevice
 
     @qos_provisioning_getQosAssignmentByDevice_400.1_schema_not_compliant
     Scenario: Invalid Argument. Generic Syntax Exception
-        Given the request body is set to any value which is not compliant with the schema at "/components/schemas/getQosAssignmentByDevice"
+        Given the request body is set to any value which is not compliant with the schema at "/components/schemas/RetrieveAssignmentByDevice"
         When the request "getQosAssignmentByDevice" is sent
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
+++ b/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDevice
+Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentByDevice
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -7,36 +7,36 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
     #   For this version, CAMARA does not allow the use of networkAccessIdentifier, so it is considered by default as not supported.
     #
     # Testing assets:
-    # * A device object with an existing QoD provisioning associated, and the request properties used for createProvisioning
-    # * A device object with NO existing QoD provisioning associated
+    # * A device object with an existing QoS assignment associated, and the request properties used for createQosAssignment
+    # * A device object with NO existing QoS assignment associated
     # * A device object identifying a device commercialized by the implementation for which the service is not applicable, if any
     #
-    # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml
+    # References to OAS spec schemas refer to schemas specified in qos-provisioning.yaml
 
 
-    Background: Common retrieveProvisioningByDevice setup
+    Background: Common getQosAssignmentByDevice setup
         Given an environment at "apiRoot"
-        And the resource "/qod-provisioning/vwip/retrieve-device-qos"                                                              |
+        And the resource "/qos-provisioning/vwip/retrieve-qos-assignments"                                                              |
         And the header "Content-Type" is set to "application/json"
-        # Unless indicated otherwise the QoD provisioning must be created by the same API client given in the access token
-        And the header "Authorization" is set to a valid access token granted to the same client that created the QoD provisioning
+        # Unless indicated otherwise the QoS assignment must be created by the same API client given in the access token
+        And the header "Authorization" is set to a valid access token granted to the same client that created the QoS assignment
         And the header "x-correlator" is set to a UUID value
 
     # Success scenarios
 
-    @qod_provisioning_retrieveProvisioningByDevice_01_get_existing_qod_provisioning_by_device
-    Scenario: Get an existing QoD Provisioning by device
-        Given a valid testing device with an existing QoD Provisioning, identified by the token or provided in the request body
-        When the request "retrieveProvisioningByDevice" is sent
+    @qos_provisioning_getQosAssignmentByDevice_01_get_existing_qos_provisioning_by_device
+    Scenario: Get an existing QoS assignment by device
+        Given a valid testing device with an existing QoS assignment, identified by the token or provided in the request body
+        When the request "getQosAssignmentByDevice" is sent
         Then the response status code is 200
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         # The response has to comply with the generic response schema which is part of the spec
-        And the response body complies with the OAS schema at "/components/schemas/ProvisioningInfo"
+        And the response body complies with the OAS schema at "/components/schemas/AssignmentInfo"
         # Additionally any success response has to comply with some constraints beyond the schema compliance
-        And the response property "$.device" exists only if provided for createProvisioning and with the same value
-        And the response property "$.qosProfile" has the value provided for createProvisioning
-        And the response property "$.sink" exists only if provided for createProvisioning and with the same value
+        And the response property "$.device" exists only if provided for createQosAssignment and with the same value
+        And the response property "$.qosProfile" has the value provided for createQosAssignment
+        And the response property "$.sink" exists only if provided for createQosAssignment and with the same value
         # sinkCredentials not explicitly mentioned to be returned if present, as this is debatable for security concerns
         And the response property "$.startedAt" exists only if "$.status" is "AVAILABLE" and the value is in the past
         And the response property "$.statusInfo" exists only if "$.status" is "UNAVAILABLE"
@@ -44,7 +44,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
 
     # Common error scenarios for management of input parameter device
 
-    @qod_provisioning_retrieveProvisioningByDevice_C01.01_device_empty
+    @qos_provisioning_getQosAssignmentByDevice_C01.01_device_empty
     Scenario: The device value is an empty object
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" is set to: {}
@@ -55,7 +55,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response property "$.message" contains a user friendly text
 
 
-    @qod_provisioning_retrieveProvisioningByDevice_C01.02_device_identifiers_not_schema_compliant
+    @qos_provisioning_getQosAssignmentByDevice_C01.02_device_identifiers_not_schema_compliant
     Scenario Outline: Some device identifier value does not comply with the schema
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
@@ -74,7 +74,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
 
   
     # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.
-    @qod_provisioning_retrieveProvisioningByDevice_C01.03_device_not_found
+    @qos_provisioning_getQosAssignmentByDevice_C01.03_device_not_found
     Scenario: Some identifier cannot be matched to a device
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" is compliant with the schema but does not identify a valid device
@@ -85,7 +85,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response property "$.message" contains a user friendly text
 
 
-@qod_provisioning_retrieveProvisioningByDevice_C01.04_unnecessary_device
+@qos_provisioning_getQosAssignmentByDevice_C01.04_unnecessary_device
     Scenario: Device not to be included when it can be deduced from the access token
         Given the header "Authorization" is set to a valid access token identifying a device
         And the request body property "$.device" is set to a valid device
@@ -96,7 +96,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response property "$.message" contains a user-friendly text
 
 
-    @qod_provisioning_retrieveProvisioningByDevice_C01.05_missing_device
+    @qos_provisioning_getQosAssignmentByDevice_C01.05_missing_device
     Scenario: Device not included and cannot be deduced from the access token
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" is not included
@@ -107,7 +107,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response property "$.message" contains a user-friendly text
 
 
-    @qod_provisioning_retrieveProvisioningByDevice_C01.06_unsupported_device
+    @qos_provisioning_getQosAssignmentByDevice_C01.06_unsupported_device
     Scenario: None of the provided device identifiers is supported by the implementation
         Given that some types of device identifiers are not supported by the implementation
         And the header "Authorization" is set to a valid access token which does not identify a single device
@@ -120,7 +120,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
 
 
     # When the service is only offered to certain types of devices or subscriptions, e.g. IoT, B2C, etc.
-    @qod_provisioning_retrieveProvisioningByDevice_C01.07_device_not_supported
+    @qos_provisioning_getQosAssignmentByDevice_C01.07_device_not_supported
     Scenario: Service not available for the device
         Given that the service is not available for all devices commercialized by the operator
         And a valid device, identified by the token or provided in the request body, for which the service is not applicable
@@ -133,7 +133,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
 
     # Several identifiers provided but they do not identify the same device
     # This scenario may happen with 2-legged access tokens, which do not identify a device
-    @qod_provisioning_retrieveProvisioningByDevice_C01.08_device_identifiers_mismatch
+    @qos_provisioning_getQosAssignmentByDevice_C01.08_device_identifiers_mismatch
     Scenario: Device identifiers mismatch
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And at least 2 types of device identifiers are supported by the implementation
@@ -146,20 +146,20 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
 
     # Errors 400
 
-    @qod_provisioning_retrieveProvisioningByDevice_400.1_schema_not_compliant
+    @qos_provisioning_getQosAssignmentByDevice_400.1_schema_not_compliant
     Scenario: Invalid Argument. Generic Syntax Exception
-        Given the request body is set to any value which is not compliant with the schema at "/components/schemas/RetrieveProvisioningByDevice"
-        When the request "retrieveProvisioningByDevice" is sent
+        Given the request body is set to any value which is not compliant with the schema at "/components/schemas/getQosAssignmentByDevice"
+        When the request "getQosAssignmentByDevice" is sent
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 400
         And the response property "$.code" is "INVALID_ARGUMENT"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_retrieveProvisioningByDevice_400.2_no_request_body
+    @qos_provisioning_getQosAssignmentByDevice_400.2_no_request_body
     Scenario: Missing request body
         Given the request body is not included
-        When the request "retrieveProvisioningByDevice" is sent
+        When the request "getQosAssignmentByDevice" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -167,10 +167,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response property "$.code" is "INVALID_ARGUMENT"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_retrieveProvisioningByDevice_400.3_empty_request_body
+    @qos_provisioning_getQosAssignmentByDevice_400.3_empty_request_body
     Scenario: Empty object as request body
         Given the request body is set to {}
-        When the request "retrieveProvisioningByDevice" is sent
+        When the request "getQosAssignmentByDevice" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -180,10 +180,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
 
     # Generic 401 errors
 
-    @qod_provisioning_retrieveProvisioningByDevice_401.1_no_authorization_header
+    @qos_provisioning_getQosAssignmentByDevice_401.1_no_authorization_header
     Scenario: No Authorization header
         Given the header "Authorization" is not sent
-        When the request "retrieveProvisioningByDevice" is sent
+        When the request "getQosAssignmentByDevice" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -192,10 +192,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response property "$.message" contains a user friendly text
 
     # In this case both codes could make sense depending on whether the access token can be refreshed or not
-    @qod_provisioning_retrieveProvisioningByDevice_401.2_expired_access_token
+    @qos_provisioning_getQosAssignmentByDevice_401.2_expired_access_token
     Scenario: Expired access token
         Given the header "Authorization" is set to an expired access token
-        When the request "retrieveProvisioningByDevice" is sent
+        When the request "getQosAssignmentByDevice" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -203,10 +203,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_retrieveProvisioningByDevice_401.3_invalid_access_token
+    @qos_provisioning_getQosAssignmentByDevice_401.3_invalid_access_token
     Scenario: Invalid access token
         Given the header "Authorization" is set to an invalid access token
-        When the request "retrieveProvisioningByDevice" is sent
+        When the request "getQosAssignmentByDevice" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -216,10 +216,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
 
     # Errors 403
 
-    @qod_provisioning_retrieveProvisioningByDevice_403.1_missing_access_token_scope
+    @qos_provisioning_getQosAssignmentByDevice_403.1_missing_access_token_scope
     Scenario: Missing access token scope
-        Given the header "Authorization" is set to an access token that does not include scope qod-provisioning:device-qos:read-by-device
-        When the request "retrieveProvisioningByDevice" is sent
+        Given the header "Authorization" is set to an access token that does not include scope qos-provisioning:qos-assignments:read-by-device
+        When the request "getQosAssignmentByDevice" is sent
         Then the response status code is 403
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -227,11 +227,11 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response property "$.code" is "PERMISSION_DENIED"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_retrieveProvisioningByDevice_403.2_different_client_id
-    Scenario: QoD provisioning not created by the API client given in the access token
+    @qos_provisioning_getQosAssignmentByDevice_403.2_different_client_id
+    Scenario: QoS assignment not created by the API client given in the access token
         # To test this, a token have to be obtained for a different client
-        Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoD provisioning
-        When the request "retrieveProvisioningByDevice" is sent
+        Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoS assignment
+        When the request "getQosAssignmentByDevice" is sent
         Then the response status code is 403
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -241,10 +241,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
 
     # Errors 404
 
-    @qod_provisioning_retrieveProvisioningByDevice_404.1_not_found
-    Scenario: Device with no existing QoD provisioning
-        Given a valid testing device without an existing QoD Provisioning, identified by the token or provided in the request body
-        When the request "retrieveProvisioningByDevice" is sent
+    @qos_provisioning_getQosAssignmentByDevice_404.1_not_found
+    Scenario: Device with no existing QoS assignment
+        Given a valid testing device without an existing QoS assignment, identified by the token or provided in the request body
+        When the request "getQosAssignmentByDevice" is sent
         Then the response status code is 404
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/qod-provisioning-revokeProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-revokeProvisioning.feature
@@ -47,7 +47,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation revokeQosAssignment
         And the response property "$.status" is "AVAILABLE"
         And the response property "$.statusInfo" is "DELETE_REQUESTED"
         And the response property "$.sink" exists only if provided for createQosAssignment and with the same value
-        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatable for security concerns
+        # sinkCredential not explicitly mentioned to be returned if present, as this is debatable for security concerns
         And the response property "$.startedAt" exists and the value is in the past
 
     @qos_provisioning_revokeQosAssignment_03_event_notification_sync
@@ -58,7 +58,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation revokeQosAssignment
         When the request "revokeQosAssignment" is sent
         Then the response status code is 204
         And an event is received at the address of the "$.sink" provided for createQosAssignment
-        And the event header "Authorization" is set to "Bearer: " + the value of "$.sinkCredentials.accessToken" provided for createQosAssignment
+        And the event header "Authorization" is set to "Bearer: " + the value of "$.sinkCredential.accessToken" provided for createQosAssignment
         And the event header "Content-Type" is set to "application/cloudevents+json"
         And the event body complies with the OAS schema at "/components/schemas/EventStatusChanged"
         # Additionally any event body has to comply with some constraints beyond the schema compliance
@@ -77,7 +77,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation revokeQosAssignment
         Then the response status code is 202
         And when the asynchronous deletion process is completed
         Then an event is received at the address of the "$.sink" provided for createQosAssignment
-        And the event header "Authorization" is set to "Bearer: " + the value of "$.sinkCredentials.accessToken" provided for createQosAssignment
+        And the event header "Authorization" is set to "Bearer: " + the value of "$.sinkCredential.accessToken" provided for createQosAssignment
         And the event header "Content-Type" is set to "application/cloudevents+json"
         And the event body complies with the OAS schema at "/components/schemas/EventStatusChanged"
         # Additionally any event body has to comply with some constraints beyond the schema compliance

--- a/code/Test_definitions/qod-provisioning-revokeProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-revokeProvisioning.feature
@@ -1,100 +1,100 @@
-Feature: CAMARA QoD Provisioning API, vwip - Operation revokeProvisioning
+Feature: CAMARA QoD Provisioning API, vwip - Operation revokeQosAssignment
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
     # * apiRoot: API root of the server URL
     #
     # Testing assets:
-    # * The ProvisioningInfo of an existing QoD Provisioning
-    # * The ProvisioningInfo of an existing QoD Provisioning with status "AVAILABLE", and with provided values for "sink" and "sinkCredential"
+    # * The AssignmentInfo of an existing QoS assignment
+    # * The AssignmentInfo of an existing QoS assignment with status "AVAILABLE", and with provided values for "sink" and "sinkCredential"
     #
-    # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml
+    # References to OAS spec schemas refer to schemas specified in qos-provisioning.yaml
 
 
-    Background: Common revokeProvisioning setup
+    Background: Common revokeQosAssignment setup
         Given an environment at "apiRoot"
-        And the resource "/qod-provisioning/vwip/device-qos/{provisioningId}"
-        # Unless indicated otherwise the QoD provisioning must be created by the same API client given in the access token
-        And the header "Authorization" is set to a valid access token granted to the same client that created the QoD provisioning
+        And the resource "/qos-provisioning/vwip/qos-assignments/{assignmentId}"
+        # Unless indicated otherwise the QoS assignment must be created by the same API client given in the access token
+        And the header "Authorization" is set to a valid access token granted to the same client that created the QoS assignment
         And the header "x-correlator" is set to a UUID value
-        And the path parameter "provisioningId" is set by default to an existing QoD provisioning ID
+        And the path parameter "assignmentId" is set by default to an existing QoS assignment ID
 
     # Success scenarios
 
-    @qod_provisioning_revokeProvisioning_01_delete_existing_qod_provisioning_sync
-    Scenario: Delete an existing QoD Provisioning synchronously
-        Given that implementation deletes QoD provisioning synchronously
-        And an existing QoD provisioning created by operation createProvisioning
-        And the path parameter "provisioningId" is set to the value for that QoD provisioning
-        When the request "revokeProvisioning" is sent
+    @qos_provisioning_revokeQosAssignment_01_delete_existing_qos_assignment_sync
+    Scenario: Delete an existing QoS assignment synchronously
+        Given that implementation deletes QoS assignment synchronously
+        And an existing QoS assignment created by operation createQosAssignment
+        And the path parameter "assignmentId" is set to the value for that QoS assignment
+        When the request "revokeQosAssignment" is sent
         Then the response status code is 204
         And the response header "x-correlator" has same value as the request header "x-correlator"
 
-    @qod_provisioning_revokeProvisioning_02_delete_existing_qod_provisioning_async
-    Scenario: Delete an existing QoD Provisioning asynchronously
-        Given that implementation deletes QoD provisioning asynchronously
-        And an existing QoD provisioning created by operation createProvisioning
-        And the path parameter "provisioningId" is set to the value for that QoD provisioning
-        When the request "revokeProvisioning" is sent
+    @qos_provisioning_revokeQosAssignment_02_delete_existing_qos_assignment_async
+    Scenario: Delete an existing QoS assignment asynchronously
+        Given that implementation deletes QoS assignment asynchronously
+        And an existing QoS assignment created by operation createQosAssignment
+        And the path parameter "assignmentId" is set to the value for that QoS assignment
+        When the request "revokeQosAssignment" is sent
         Then the response status code is 202
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         # The response has to comply with the generic response schema which is part of the spec
-        And the response body complies with the OAS schema at "/components/schemas/ProvisioningInfo"
+        And the response body complies with the OAS schema at "/components/schemas/AssignmentInfo"
         # Additionally any success response has to comply with some constraints beyond the schema compliance
-        And the response property "$.device" exists only if provided for createProvisioning and with the same value
-        And the response property "$.qosProfile" has the value provided for createProvisioning
+        And the response property "$.device" exists only if provided for createQosAssignment and with the same value
+        And the response property "$.qosProfile" has the value provided for createQosAssignment
         And the response property "$.status" is "AVAILABLE"
         And the response property "$.statusInfo" is "DELETE_REQUESTED"
-        And the response property "$.sink" exists only if provided for createProvisioning and with the same value
+        And the response property "$.sink" exists only if provided for createQosAssignment and with the same value
         # sinkCredentials not explicitly mentioned to be returned if present, as this is debatable for security concerns
         And the response property "$.startedAt" exists and the value is in the past
 
-    @qod_provisioning_revokeProvisioning_03_event_notification_sync
-    Scenario: Event is received if the provisioning was AVAILABLE and sink was provided (synchronous deletion)
-        Given that implementation deletes QoD provisioning synchronously
-        And an existing QoD provisioning created by operation createProvisioning with provided values for "sink" and "sinkCredential", and with status "AVAILABLE"
-        And the path parameter "provisioningId" is set to the value for that QoD provisioning
-        When the request "revokeProvisioning" is sent
+    @qos_provisioning_revokeQosAssignment_03_event_notification_sync
+    Scenario: Event is received if the QoS assignment was AVAILABLE and sink was provided (synchronous deletion)
+        Given that implementation deletes QoS assignment synchronously
+        And an existing QoS assignment created by operation createQosAssignment with provided values for "sink" and "sinkCredential", and with status "AVAILABLE"
+        And the path parameter "assignmentId" is set to the value for that QoS assignment
+        When the request "revokeQosAssignment" is sent
         Then the response status code is 204
-        And an event is received at the address of the "$.sink" provided for createProvisioning
-        And the event header "Authorization" is set to "Bearer: " + the value of "$.sinkCredentials.accessToken" provided for createProvisioning
+        And an event is received at the address of the "$.sink" provided for createQosAssignment
+        And the event header "Authorization" is set to "Bearer: " + the value of "$.sinkCredentials.accessToken" provided for createQosAssignment
         And the event header "Content-Type" is set to "application/cloudevents+json"
         And the event body complies with the OAS schema at "/components/schemas/EventStatusChanged"
         # Additionally any event body has to comply with some constraints beyond the schema compliance
         And the event body property "$.id" is unique
-        And the event body property "$.type" is set to "org.camaraproject.qod-provisioning.v0.status-changed"
-        And the event body property "$.data.provisioningId" as returned for createProvisioning
+        And the event body property "$.type" is set to "org.camaraproject.qos-provisioning.v0.status-changed"
+        And the event body property "$.data.assignmentId" as returned for createQosAssignment
         And the event body property "$.data.status" is "UNAVAILABLE"
         And the event body property "$.data.statusInfo" is "DELETE_REQUESTED"
 
-    @qod_provisioning_revokeProvisioning_04_event_notification_async
-    Scenario: Event is received if the provisioning was AVAILABLE and sink was provided (asynchronous deletion)
-        Given that implementation deletes QoD provisioning asynchronously
-        And an existing QoD provisioning created by operation createProvisioning with provided values for "sink" and "sinkCredential", and with status "AVAILABLE"
-        And the path parameter "provisioningId" is set to the value for that QoD provisioning
-        When the request "revokeProvisioning" is sent
+    @qos_provisioning_revokeQosAssignment_04_event_notification_async
+    Scenario: Event is received if the QoS assignment was AVAILABLE and sink was provided (asynchronous deletion)
+        Given that implementation deletes QoS assignment asynchronously
+        And an existing QoS assignment created by operation createQosAssignment with provided values for "sink" and "sinkCredential", and with status "AVAILABLE"
+        And the path parameter "assignmentId" is set to the value for that QoS assignment
+        When the request "revokeQosAssignment" is sent
         Then the response status code is 202
         And when the asynchronous deletion process is completed
-        Then an event is received at the address of the "$.sink" provided for createProvisioning
-        And the event header "Authorization" is set to "Bearer: " + the value of "$.sinkCredentials.accessToken" provided for createProvisioning
+        Then an event is received at the address of the "$.sink" provided for createQosAssignment
+        And the event header "Authorization" is set to "Bearer: " + the value of "$.sinkCredentials.accessToken" provided for createQosAssignment
         And the event header "Content-Type" is set to "application/cloudevents+json"
         And the event body complies with the OAS schema at "/components/schemas/EventStatusChanged"
         # Additionally any event body has to comply with some constraints beyond the schema compliance
         And the event body property "$.id" is unique
-        And the event body property "$.type" is set to "org.camaraproject.qod-provisioning.v0.status-changed"
-        And the event body property "$.data.provisioningId" as returned for createProvisioning
+        And the event body property "$.type" is set to "org.camaraproject.qos-provisioning.v0.status-changed"
+        And the event body property "$.data.assignmentId" as returned for createQosAssignment
         And the event body property "$.data.status" is "UNAVAILABLE"
         And the event body property "$.data.statusInfo" is "DELETE_REQUESTED"
 
     # Errors 400
 
-    # 400 errors are not expected for this operation unless the implementation validates the format of provisioningId
+    # 400 errors are not expected for this operation unless the implementation validates the format of assignmentId
     # 404 NOT_FOUND is an alternative if path parameter format is not validated
-    @qod_provisioning_revokeProvisioning_400.1_invalid_id
+    @qos_provisioning_revokeQosAssignment_400.1_invalid_id
     Scenario: Invalid Argument. Generic Syntax Exception
-        Given the path parameter "provisioningId" has not a UUID format
-        When the request "revokeProvisioning" is sent
+        Given the path parameter "assignmentId" has not a UUID format
+        When the request "revokeQosAssignment" is sent
         Then the response status code is 404
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -104,10 +104,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation revokeProvisioning
 
     # Generic 401 errors
 
-    @qod_provisioning_revokeProvisioning_401.1_no_authorization_header
+    @qos_provisioning_revokeQosAssignment_401.1_no_authorization_header
     Scenario: No Authorization header
         Given the header "Authorization" is not sent
-        When the request "revokeProvisioning" is sent
+        When the request "revokeQosAssignment" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -116,10 +116,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation revokeProvisioning
         And the response property "$.message" contains a user friendly text
 
     # In this case both codes could make sense depending on whether the access token can be refreshed or not
-    @qod_provisioning_revokeProvisioning_401.2_expired_access_token
+    @qos_provisioning_revokeQosAssignment_401.2_expired_access_token
     Scenario: Expired access token
         Given the header "Authorization" is set to an expired access token
-        When the request "revokeProvisioning" is sent
+        When the request "revokeQosAssignment" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -127,10 +127,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation revokeProvisioning
         And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_revokeProvisioning_401.3_invalid_access_token
+    @qos_provisioning_revokeQosAssignment_401.3_invalid_access_token
     Scenario: Invalid access token
         Given the header "Authorization" is set to an invalid access token
-        When the request "revokeProvisioning" is sent
+        When the request "revokeQosAssignment" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -140,10 +140,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation revokeProvisioning
 
     # Errors 403
 
-    @qod_provisioning_revokeProvisioning_403.1_missing_access_token_scope
+    @qos_provisioning_revokeQosAssignment_403.1_missing_access_token_scope
     Scenario: Missing access token scope
-        Given the header "Authorization" is set to an access token that does not include scope qod-provisioning:device-qos:delete
-        When the request "revokeProvisioning" is sent
+        Given the header "Authorization" is set to an access token that does not include scope qos-provisioning:qos-assignments:delete
+        When the request "revokeQosAssignment" is sent
         Then the response status code is 403
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -151,11 +151,11 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation revokeProvisioning
         And the response property "$.code" is "PERMISSION_DENIED"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_revokeProvisioning_403.2_different_client_id
-    Scenario: QoD provisioning not created by the API client given in the access token
+    @qos_provisioning_revokeQosAssignment_403.2_different_client_id
+    Scenario: QoS assignment not created by the API client given in the access token
         # To test this, a token have to be obtained by a different client
-        Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoD provisioning
-        When the request "revokeProvisioning" is sent
+        Given the header "Authorization" is set to a valid access token emitted to a client which did not created the QoS assignment
+        When the request "revokeQosAssignment" is sent
         Then the response status code is 403
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -165,10 +165,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation revokeProvisioning
 
     # Errors 404
 
-    @qod_provisioning_revokeProvisioning_404.1_not_found
-    Scenario: provisioningId of a no existing QoD provisioning
-        Given the path parameter "provisioningId" is set to a random UUID
-        When the request "revokeProvisioning" is sent
+    @qos_provisioning_revokeQosAssignment_404.1_not_found
+    Scenario: assignmentId of a no existing QoS assignment
+        Given the path parameter "assignmentId" is set to a random UUID
+        When the request "revokeQosAssignment" is sent
         Then the response status code is 404
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/qod-provisioning-triggerProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-triggerProvisioning.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
+Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -7,34 +7,34 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
     #   For this version, CAMARA does not allow the use of networkAccessIdentifier, so it is considered by default as not supported.
     #
     # Testing assets:
-    # * A device object applicable for QoD provisioning service
+    # * A device object applicable for QoS Provisioning service
     # * A device object identifying a device commercialized by the implementation for which the service is not applicable, if any
     #
-    # References to OAS spec schemas refer to schemas specified in qod-provisioning.yaml
+    # References to OAS spec schemas refer to schemas specified in qos-provisioning.yaml
 
 
-    Background: Common triggerProvisioning setup
+    Background: Common createQosAssignment setup
         Given an environment at "apiRoot"
-        And the resource "/qod-provisioning/vwip/device-qos"
+        And the resource "/qos-provisioning/vwip/qos-assignments"
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" is set to a UUID value
         # Properties not explicitly overwritten in the Scenarios can take any values compliant with the schema
-        And the request body is set by default to a request body compliant with the schema at "/components/schemas/triggerProvisioning"
+        And the request body is set by default to a request body compliant with the schema at "/components/schemas/CreateQosAssignment"
 
     # Success scenarios
 
-    @qod_provisioning_triggerProvisioning_01_generic_success_scenario
+    @qos_provisioning_createQosAssignment_01_generic_success_scenario
     Scenario: Common validations for any success scenario
         # Valid testing device and default request body compliant with the schema
         Given a valid testing device supported by the service, identified by the token or provided in the request body
         And the request property "$.qosProfile" is set to a valid QoS Profile as returned by QoS Profiles API
-        When the request "triggerProvisioning" is sent
+        When the request "createQosAssignment" is sent
         Then the response status code is 201
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         # The response has to comply with the generic response schema which is part of the spec
-        And the response body complies with the OAS schema at "/components/schemas/ProvisioningInfo"
+        And the response body complies with the OAS schema at "/components/schemas/AssignmentInfo"
         # Additionally any success response has to comply with some constraints beyond the schema compliance
         And the response property "$.device" exists only if provided in the request body and with the same value
         And the response property "$.qosProfile" has the same value as in the request body
@@ -43,8 +43,8 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response property "$.startedAt" exists only if "$.status" is "AVAILABLE" and the value is in the past
         And the response property "$.statusInfo" exists only if "$.status" is "UNAVAILABLE"
 
-    @qod_provisioning_triggerProvisioning_02_event_notification
-    Scenario: Events for the outcome of provisioning creation if sink is provided
+    @qos_provisioning_createQosAssignment_02_event_notification
+    Scenario: Events for the outcome of QoS Provisioning creation if sink is provided
         Given a valid testing device supported by the service, identified by the token or provided in the request body
         And the request property "$.qosProfile" is set to a valid QoS Profile as returned by QoS Profiles API
         And the request property "$.sink" is set to a URL when events can be monitored
@@ -52,35 +52,35 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the request property "$.sinkCredentials.accessTokenType" is set to "bearer"
         And the request property "$.sinkCredentials.accessToken" is set to a valid access token accepted by the events receiver
         And the request property "$.sinkCredentials.accessTokenExpiresUtc" is set to a value long enough in the future
-        And the request "triggerProvisioning" is sent
+        And the request "createQosAssignment" is sent
         And the response status code is 201
         # There is no specific limit defined for the process to end
-        When the provisioning outcome is known
+        When the QoS assignment outcome is known
         Then an event is received at the address of the request property "$.sink"
         And the event header "Authorization" is set to "Bearer: " + the value of the request property "$.sinkCredentials.accessToken"
         And the event header "Content-Type" is set to "application/cloudevents+json"
         And the event body complies with the OAS schema at "/components/schemas/EventStatusChanged"
         # Additionally any event body has to comply with some constraints beyond the schema compliance
         And the event body property "$.id" is unique
-        And the event body property "$.type" is set to "org.camaraproject.qod-provisioning.v0.status-changed"
-        And the event body property "$.data.provisioningId" has the same value as triggerProvisioning response property "$.provisioningId"
+        And the event body property "$.type" is set to "org.camaraproject.qos-provisioning.v0.status-changed"
+        And the event body property "$.data.assignmentId" has the same value as createQosAssignment response property "$.assignmentId"
         And the event body property "$.data.status" is "AVAILABLE" or "UNAVAILABLE"
         And the event body property "$.data.statusInfo" exists only if "$.data.status" is "UNAVAILABLE"
 
-    @qod_provisioning_triggerProvisioning_03_3_legged_missing_device
+    @qos_provisioning_createQosAssignment_03_3_legged_missing_device
     Scenario: Device is not returned if not included in the creation request
         Given the header "Authorization" is set to a valid 3-legged access token associated to a valid testing device supported by the service
         And the request property "$.device" is not included
-        When the request "triggerProvisioning" is sent
+        When the request "createQosAssignment" is sent
         Then the response status code is 201
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
-        And the response body complies with the OAS schema at "/components/schemas/ProvisioningInfo"
+        And the response body complies with the OAS schema at "/components/schemas/AssignmentInfo"
         And the response property "$.device" does not exist
 
     # Common error scenarios for management of input parameter device
 
-    @qod_provisioning_triggerProvisioning_C01.01_device_empty
+    @qos_provisioning_createQosAssignment_C01.01_device_empty
     Scenario: The device value is an empty object
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" is set to: {}
@@ -91,7 +91,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response property "$.message" contains a user friendly text
 
 
-    @qod_provisioning_triggerProvisioning_C01.02_device_identifiers_not_schema_compliant
+    @qos_provisioning_createQosAssignment_C01.02_device_identifiers_not_schema_compliant
     Scenario Outline: Some device identifier value does not comply with the schema
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
@@ -110,7 +110,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
 
   
     # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.
-    @qod_provisioning_triggerProvisioning_C01.03_device_not_found
+    @qos_provisioning_createQosAssignment_C01.03_device_not_found
     Scenario: Some identifier cannot be matched to a device
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" is compliant with the schema but does not identify a valid device
@@ -121,7 +121,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response property "$.message" contains a user friendly text
 
 
-    @qod_provisioning_triggerProvisioning_C01.04_unnecessary_device
+    @qos_provisioning_createQosAssignment_C01.04_unnecessary_device
     Scenario: Device not to be included when it can be deduced from the access token
         Given the header "Authorization" is set to a valid access token identifying a device
         And the request body property "$.device" is set to a valid device
@@ -132,7 +132,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response property "$.message" contains a user-friendly text
 
 
-    @qod_provisioning_triggerProvisioning_C01.05_missing_device
+    @qos_provisioning_createQosAssignment_C01.05_missing_device
     Scenario: Device not included and cannot be deduced from the access token
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" is not included
@@ -143,7 +143,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response property "$.message" contains a user-friendly text
 
 
-    @qod_provisioning_triggerProvisioning_C01.06_unsupported_device
+    @qos_provisioning_createQosAssignment_C01.06_unsupported_device
     Scenario: None of the provided device identifiers is supported by the implementation
         Given that some types of device identifiers are not supported by the implementation
         And the header "Authorization" is set to a valid access token which does not identify a single device
@@ -156,7 +156,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
 
 
     # When the service is only offered to certain types of devices or subscriptions, e.g. IoT, B2C, etc.
-    @qod_provisioning_triggerProvisioning_C01.07_device_not_supported
+    @qos_provisioning_createQosAssignment_C01.07_device_not_supported
     Scenario: Service not available for the device
         Given that the service is not available for all devices commercialized by the operator
         And a valid device, identified by the token or provided in the request body, for which the service is not applicable
@@ -169,7 +169,7 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
 
     # Several identifiers provided but they do not identify the same device
     # This scenario may happen with 2-legged access tokens, which do not identify a device
-    @qod_provisioning_triggerProvisioning_C01.08_device_identifiers_mismatch
+    @qos_provisioning_createQosAssignment_C01.08_device_identifiers_mismatch
     Scenario: Device identifiers mismatch
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And at least 2 types of device identifiers are supported by the implementation
@@ -182,10 +182,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
 
     # Errors 400
 
-    @qod_provisioning_triggerProvisioning_400.1_schema_not_compliant
+    @qos_provisioning_createQosAssignment_400.1_schema_not_compliant
     Scenario: Invalid Argument. Generic Syntax Exception
-        Given the request body is set to any value which is not compliant with the schema at "/components/schemas/triggerProvisioning"
-        When the request "triggerProvisioning" is sent
+        Given the request body is set to any value which is not compliant with the schema at "/components/schemas/createQosAssignment"
+        When the request "createQosAssignment" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -193,10 +193,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response property "$.code" is "INVALID_ARGUMENT"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_triggerProvisioning_400.2_no_request_body
+    @qos_provisioning_createQosAssignment_400.2_no_request_body
     Scenario: Missing request body
         Given the request body is not included
-        When the request "triggerProvisioning" is sent
+        When the request "createQosAssignment" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -204,10 +204,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response property "$.code" is "INVALID_ARGUMENT"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_triggerProvisioning_400.3_empty_request_body
+    @qos_provisioning_createQosAssignment_400.3_empty_request_body
     Scenario: Empty object as request body
         Given the request body is set to {}
-        When the request "triggerProvisioning" is sent
+        When the request "createQosAssignment" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -216,10 +216,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response property "$.message" contains a user friendly text
 
     # PLAIN and REFRESHTOKEN are considered in the schema so INVALID_ARGUMENT is not expected
-    @qod_provisioning_triggerProvisioning_400.7_invalid_sink_credential
+    @qos_provisioning_createQosAssignment_400.7_invalid_sink_credential
     Scenario Outline: Invalid credential
         Given the request body property  "$.sinkCredential.credentialType" is set to "<unsupported_credential_type>"
-        When the request "triggerProvisioning" is sent
+        When the request "createQosAssignment" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -234,10 +234,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
 
     # Only "bearer" is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction,
     # and both could be accepted
-    @qod_provisioning_triggerProvisioning_400.8_sink_credential_invalid_token
+    @qos_provisioning_createQosAssignment_400.8_sink_credential_invalid_token
     Scenario: Invalid token
         Given the request body property  "$.sinkCredential.accessTokenType" is set to a value other than "bearer"
-        When the request "triggerProvisioning" is sent
+        When the request "createQosAssignment" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -246,10 +246,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response property "$.message" contains a user friendly text
 
     # TBD if we neeed a dedicated code
-    @qod_provisioning_triggerProvisioning_400.9_non_existent_qos_profile
+    @qos_provisioning_createQosAssignment_400.9_non_existent_qos_profile
     Scenario: Non existent QoS profile
         Given the request body property "qosProfile" is set to a non-existent QoS Profile
-        When the request "triggerProvisioning" is sent
+        When the request "createQosAssignment" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -259,10 +259,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
 
     # Generic 401 errors
 
-    @qod_provisioning_triggerProvisioning_401.1_no_authorization_header
+    @qos_provisioning_createQosAssignment_401.1_no_authorization_header
     Scenario: No Authorization header
         Given the header "Authorization" is removed
-        When the request "triggerProvisioning" is sent
+        When the request "createQosAssignment" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -271,10 +271,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response property "$.message" contains a user friendly text
 
     # In this case both codes could make sense depending on whether the access token can be refreshed or not
-    @qod_provisioning_triggerProvisioning_401.2_expired_access_token
+    @qos_provisioning_createQosAssignment_401.2_expired_access_token
     Scenario: Expired access token
         Given the header "Authorization" is set to an expired access token
-        When the request "triggerProvisioning" is sent
+        When the request "createQosAssignment" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -282,10 +282,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response property "$.code" is "UNAUTHENTICATED"
         And the response property "$.message" contains a user friendly text
 
-    @qod_provisioning_triggerProvisioning_401.3_invalid_access_token
+    @qos_provisioning_createQosAssignment_401.3_invalid_access_token
     Scenario: Invalid access token
         Given the header "Authorization" is set to an invalid access token
-        When the request "triggerProvisioning" is sent
+        When the request "createQosAssignment" is sent
         Then the response status code is 401
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -295,10 +295,10 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
 
     # Errors 403
 
-    @qod_provisioning_triggerProvisioning_403.1_missing_access_token_scope
+    @qos_provisioning_createQosAssignment_403.1_missing_access_token_scope
     Scenario: Missing access token scope
-        Given the header "Authorization" is set to an access token that does not include scope qod-provisioning:device-qos:create
-        When the request "triggerProvisioning" is sent
+        Given the header "Authorization" is set to an access token that does not include scope qos-provisioning:qos-assignments:create
+        When the request "createQosAssignment" is sent
         Then the response status code is 403
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
@@ -308,11 +308,11 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
 
     # Errors 409
 
-    @qod_provisioning_triggerProvisioning_409.1_provisioning_conflict
-    Scenario: Provisioning conflict
+    @qos_provisioning_createQosAssignment_409.1_provisioning_conflict
+    Scenario: Assignment conflict
         Given a valid testing device supported by the service, identified by the token or provided in the request body
-        And a QoD provisioning already exists for that device
-        When the request "triggerProvisioning" is sent
+        And a QoS assignment already exists for that device
+        When the request "createQosAssignment" is sent
         And the response header "x-correlator" has same value as the request header "x-correlator"
         And the response header "Content-Type" is "application/json"
         And the response property "$.status" is 409

--- a/code/Test_definitions/qod-provisioning-triggerProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-triggerProvisioning.feature
@@ -20,7 +20,7 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" is set to a UUID value
         # Properties not explicitly overwritten in the Scenarios can take any values compliant with the schema
-        And the request body is set by default to a request body compliant with the schema at "/components/schemas/CreateQosAssignment"
+        And the request body is set by default to a request body compliant with the schema at "/components/schemas/CreateAssignment"
 
     # Success scenarios
 
@@ -39,7 +39,7 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
         And the response property "$.device" exists only if provided in the request body and with the same value
         And the response property "$.qosProfile" has the same value as in the request body
         And the response property "$.sink" exists only if provided in the request body and with the same value
-        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatable for security concerns
+        # sinkCredential not explicitly mentioned to be returned if present, as this is debatable for security concerns
         And the response property "$.startedAt" exists only if "$.status" is "AVAILABLE" and the value is in the past
         And the response property "$.statusInfo" exists only if "$.status" is "UNAVAILABLE"
 
@@ -48,16 +48,16 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
         Given a valid testing device supported by the service, identified by the token or provided in the request body
         And the request property "$.qosProfile" is set to a valid QoS Profile as returned by QoS Profiles API
         And the request property "$.sink" is set to a URL when events can be monitored
-        And the request property "$.sinkCredentials.credentialType" is set to "ACCESSTOKEN"
-        And the request property "$.sinkCredentials.accessTokenType" is set to "bearer"
-        And the request property "$.sinkCredentials.accessToken" is set to a valid access token accepted by the events receiver
-        And the request property "$.sinkCredentials.accessTokenExpiresUtc" is set to a value long enough in the future
+        And the request property "$.sinkCredential.credentialType" is set to "ACCESSTOKEN"
+        And the request property "$.sinkCredential.accessTokenType" is set to "bearer"
+        And the request property "$.sinkCredential.accessToken" is set to a valid access token accepted by the events receiver
+        And the request property "$.sinkCredential.accessTokenExpiresUtc" is set to a value long enough in the future
         And the request "createQosAssignment" is sent
         And the response status code is 201
         # There is no specific limit defined for the process to end
         When the QoS assignment outcome is known
         Then an event is received at the address of the request property "$.sink"
-        And the event header "Authorization" is set to "Bearer: " + the value of the request property "$.sinkCredentials.accessToken"
+        And the event header "Authorization" is set to "Bearer: " + the value of the request property "$.sinkCredential.accessToken"
         And the event header "Content-Type" is set to "application/cloudevents+json"
         And the event body complies with the OAS schema at "/components/schemas/EventStatusChanged"
         # Additionally any event body has to comply with some constraints beyond the schema compliance
@@ -102,11 +102,11 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
         And the response property "$.message" contains a user friendly text
         
         Examples:
-            | device_identifier          | oas_spec_schema                             |
-            | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-            | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
-            | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
-            | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
+            | device_identifier                | oas_spec_schema                             |
+            | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
+            | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+            | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
+            | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
   
     # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.
@@ -184,7 +184,7 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
 
     @qos_provisioning_createQosAssignment_400.1_schema_not_compliant
     Scenario: Invalid Argument. Generic Syntax Exception
-        Given the request body is set to any value which is not compliant with the schema at "/components/schemas/createQosAssignment"
+        Given the request body is set to any value which is not compliant with the schema at "/components/schemas/CreateAssignment"
         When the request "createQosAssignment" is sent
         Then the response status code is 400
         And the response header "x-correlator" has same value as the request header "x-correlator"


### PR DESCRIPTION
#### What type of PR is this?

* cleanup
* documentation

#### What this PR does / why we need it:

The API specification has undergone several significant improvements to address terminology issues and enhance clarity:

* Title changed from "QoD Provisioning API" to "QoS Provisioning", updating all related tags, scopes, urls, eventTypes etc
* Better clarify that "provisioning" is a process, not a thing
* Paths changed: 
  -  `/device-qos` to `/qos-assignments`
  - `/retrieve-device-qos` to `/retrieve-qos-assignment`
* Updated operation IDs to be more descriptive (e.g., triggerQosProvisioning)
* Improved endpoint summaries and descriptions

#### Which issue(s) this PR fixes:

Fixes #415 

#### Special notes for reviewers:

- **Filename has not been renamed so changes are easier to detect and review, but if we agree on the new name we should later rename it**


#### Changelog input

```
- API renamed to QoS Provisioning
- URLs and paths changed
- Descriptions enhanced 
```
