### PR TITLE
Update OAS definitions to remove IDENTIFIER_MISMATCH error code

### DIFF
--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -1107,7 +1107,7 @@ components:
         qosProfile: QOS_L
         sink: https://application-server.com/callback
         provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
-        qosStatus: REQUESTED
+        status: REQUESTED
 
     PROVISIONING_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION:
       summary: Successful provisioning creation with device disambiguation
@@ -1118,7 +1118,7 @@ components:
         qosProfile: QOS_L
         sink: https://application-server.com/callback
         provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
-        qosStatus: REQUESTED
+        status: REQUESTED
 
     PROVISIONING_AVAILABLE:
       summary: QoD provisioning status is available with device disambiguation

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -166,10 +166,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProvisioningInfo"
               examples:
-                Successful Provisioning Creation:
-                  $ref: "#/components/examples/PROVISIONING_CREATION_EXAMPLE"
-                Successful Provisioning Creation with Device in the Response:
-                  $ref: "#/components/examples/PROVISIONING_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE"
+                Successful QoS Profile Assignment Creation:
+                  $ref: "#/components/examples/ASSIGNMENT_CREATION_EXAMPLE"
+                Successful QoS Profile Assignment Creation with Device in the response:
+                  $ref: "#/components/examples/ASSIGNMENT_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE"
         "400":
           $ref: "#/components/responses/TriggerProvisioning400"
         "401":

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -214,8 +214,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProvisioningInfo"
               examples:
-                PROVISIONING_AVAILABLE:
-                  $ref: "#/components/examples/PROVISIONING_AVAILABLE"
                 PROVISIONING_UNAVAILABLE:
                   $ref: "#/components/examples/PROVISIONING_UNAVAILABLE"
                 PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
@@ -324,6 +322,8 @@ paths:
               examples:
                 PROVISIONING_AVAILABLE:
                   $ref: "#/components/examples/PROVISIONING_AVAILABLE"
+                PROVISIONING_UNAVAILABLE:
+                  $ref: "#/components/examples/PROVISIONING_UNAVAILABLE"
                 PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
                   $ref: "#/components/examples/PROVISIONING_AVAILABLE_WITHOUT_DEVICE"
         "400":
@@ -1120,7 +1120,7 @@ components:
 
     PROVISIONING_AVAILABLE:
       summary: QoD provisioning status is available
-      description: The provisioning has become available
+      description: The provisioning has become available and device disambiguation is required
       value:
         device:
           phoneNumber: "+123456789"
@@ -1152,7 +1152,7 @@ components:
         statusInfo: NETWORK_TERMINATED
 
     PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
-      summary: QoD provisioning status is available but no device information is provided
+      summary: QoD provisioning status is available
       description: Device is optional in responses and must not be provided if it was not provided in the request
       value:
         qosProfile: QOS_M

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -14,7 +14,7 @@ info:
     Latency, throughput or priority requirements of the application mapped to relevant QoS profile values. The set of QoS Profiles that a network operator is offering may be retrieved via the `qos-profiles` API (cf. https://github.com/camaraproject/QualityOnDemand/) or will be agreed during the onboarding with the API service provider.
 
     * **Identifier for the device**:
-    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone Number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session details. If only a single device identifier is provided, the implementation may or may not include the device identifier in the session details.
+    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone Number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the provisioning details. If only a single device identifier is provided, the implementation may or may not include the device identifier in the provisioning details.
 
       Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
@@ -1101,7 +1101,7 @@ components:
 
   examples:
     PROVISIONING_CREATION_EXAMPLE:
-      summary: Successful provisioning creation
+      summary: Successful provisioning creation without device in the provisioning details
       description: Example response after a new QoS provisioning has been created using a 3-legged access token, or possibly a single device identifier
       value:
         qosProfile: QOS_L
@@ -1110,7 +1110,7 @@ components:
         status: REQUESTED
 
     PROVISIONING_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE:
-      summary: Successful provisioning creation with device disambiguation
+      summary: Successful provisioning creation with device in the provisioning details
       description: Example response after a new QoS provisioning has been created using a 2-legged access token with multiple device identifiers, or possibly only a single device identifier
       value:
         device:
@@ -1121,8 +1121,8 @@ components:
         status: REQUESTED
 
     PROVISIONING_AVAILABLE:
-      summary: QoD provisioning status is available with device disambiguation
-      description: The provisioning has become available, but multiple device identifiers were provided and hence device disambiguation is required
+      summary: QoD provisioning status is available with device in the provisioning details
+      description: The provisioning has become available, and the device to which the provisioning applies is included in the provisioning details
       value:
         device:
           phoneNumber: "+123456789"

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -14,7 +14,7 @@ info:
     Latency, throughput or priority requirements of the application mapped to relevant QoS profile values. The set of QoS Profiles that a network operator is offering may be retrieved via the `qos-profiles` API (cf. https://github.com/camaraproject/QualityOnDemand/) or will be agreed during the onboarding with the API service provider.
 
     * **Identifier for the device**:
-    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone Number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session details. If only a single device identifier is provided, the implementation may or may not include the device identifier in the session details.
 
       Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
@@ -167,8 +167,8 @@ paths:
               examples:
                 Successful Provisioning Creation:
                   $ref: "#/components/examples/PROVISIONING_CREATION_EXAMPLE"
-                Successful Provisioning Creation With Device Disambiguation:
-                  $ref: "#/components/examples/PROVISIONING_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION"
+                Successful Provisioning Creation with Device in the Response:
+                  $ref: "#/components/examples/PROVISIONING_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE"
         "400":
           $ref: "#/components/responses/TriggerProvisioning400"
         "401":
@@ -1102,16 +1102,16 @@ components:
   examples:
     PROVISIONING_CREATION_EXAMPLE:
       summary: Successful provisioning creation
-      description: Example response after a new QoS provisioning has been created using a 3-legged access token or single device identifier
+      description: Example response after a new QoS provisioning has been created using a 3-legged access token, or possibly a single device identifier
       value:
         qosProfile: QOS_L
         sink: https://application-server.com/callback
         provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         status: REQUESTED
 
-    PROVISIONING_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION:
+    PROVISIONING_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE:
       summary: Successful provisioning creation with device disambiguation
-      description: Example response after a new QoS provisioning has been created using multiple device identifiers
+      description: Example response after a new QoS provisioning has been created using a 2-legged access token with multiple device identifiers, or possibly only a single device identifier
       value:
         device:
           phoneNumber: "+123456789"

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -15,7 +15,7 @@ info:
 
     * **Identifier for the device**:
     At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
-    
+
       Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Notification URL and token**:

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -215,12 +215,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProvisioningInfo"
               examples:
-                PROVISIONING_AVAILABLE:
-                  $ref: "#/components/examples/PROVISIONING_AVAILABLE"
-                PROVISIONING_UNAVAILABLE:
-                  $ref: "#/components/examples/PROVISIONING_UNAVAILABLE"
-                PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
-                  $ref: "#/components/examples/PROVISIONING_AVAILABLE_WITHOUT_DEVICE"
+                ASSIGNMENT_AVAILABLE:
+                  $ref: "#/components/examples/ASSIGNMENT_AVAILABLE"
+                ASSIGNMENT_UNAVAILABLE:
+                  $ref: "#/components/examples/ASSIGNMENT_UNAVAILABLE"
+                ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE:
+                  $ref: "#/components/examples/ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -1122,8 +1122,8 @@ components:
         status: REQUESTED
 
     PROVISIONING_AVAILABLE:
-      summary: QoD provisioning status is available with device in the provisioning details
-      description: The provisioning has become available, and the device to which the provisioning applies is included in the provisioning details
+      summary: QoS provisioning status is available with device in the assignment details
+      description: The QoS profile assignment has become available, and the device to which the assignment applies is included in the assignment details
       value:
         device:
           phoneNumber: "+123456789"

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -14,7 +14,8 @@ info:
     Latency, throughput or priority requirements of the application mapped to relevant QoS profile values. The set of QoS Profiles that a network operator is offering may be retrieved via the `qos-profiles` API (cf. https://github.com/camaraproject/QualityOnDemand/) or will be agreed during the onboarding with the API service provider.
 
     * **Identifier for the device**:
-    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone Number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the provisioning details. If only a single device identifier is provided, the implementation may or may not include the device identifier in the provisioning details.
+    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone Number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the provisioning details. If only a single device identifier is provided, the implementation may or may not include the device identifier in the assignment details.
+
 
       Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -134,8 +134,8 @@ paths:
                     schema:
                       $ref: "#/components/schemas/CloudEvent"
                     examples:
-                      PROVISIONING_STATUS_CHANGED_EXAMPLE:
-                        $ref: "#/components/examples/PROVISIONING_STATUS_CHANGED_EXAMPLE"
+                      ASSIGNMENT_STATUS_CHANGED_EXAMPLE:
+                        $ref: "#/components/examples/ASSIGNMENT_STATUS_CHANGED_EXAMPLE"
               responses:
                 "204":
                   description: Successful notification

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -323,12 +323,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProvisioningInfo"
               examples:
-                PROVISIONING_AVAILABLE:
-                  $ref: "#/components/examples/PROVISIONING_AVAILABLE"
+                ASSIGNMENT_AVAILABLE:
+                  $ref: "#/components/examples/ASSIGNMENT_AVAILABLE"
                 ASSIGNMENT_UNAVAILABLE:
                   $ref: "#/components/examples/ASSIGNMENT_UNAVAILABLE"
-                PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
-                  $ref: "#/components/examples/PROVISIONING_AVAILABLE_WITHOUT_DEVICE"
+                ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE:
+                  $ref: "#/components/examples/ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -1121,8 +1121,8 @@ components:
         assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         status: REQUESTED
 
-    PROVISIONING_AVAILABLE:
-      summary: QoS provisioning status is available with device in the assignment details
+    ASSIGNMENT_AVAILABLE:
+      summary: QoS assignment status is available with device in the assignment details
       description: The QoS profile assignment has become available, and the device to which the assignment applies is included in the assignment details
       value:
         device:
@@ -1134,13 +1134,13 @@ components:
           accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
           accessTokenType: bearer
-        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         startedAt: "2024-05-12T17:32:01Z"
         status: AVAILABLE
 
-    PROVISIONING_UNAVAILABLE:
+    ASSIGNMENT_UNAVAILABLE:
       summary: QoD provisioning status is unavailable
-      description: The provisioning could not be created or is not active anymore
+      description: The sssignment could not be created or is not active anymore
       value:
         qosProfile: QOS_L
         sink: https://application-server.com/callback
@@ -1149,14 +1149,13 @@ components:
           accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
           accessTokenType: bearer
-        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         startedAt: "2024-05-12T17:32:01Z"
         status: UNAVAILABLE
         statusInfo: NETWORK_TERMINATED
 
-    PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
-      summary: QoS provisioning status is available
-
+    ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE:
+      summary: QoS sssignment status is available
       description: Device is optional in responses and must not be provided if it was not provided in the request
       value:
         qosProfile: QOS_M
@@ -1166,13 +1165,13 @@ components:
           accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
           accessTokenType: bearer
-        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         startedAt: "2024-05-12T17:32:01Z"
         status: AVAILABLE
 
-    PROVISIONING_STATUS_CHANGED_EXAMPLE:
-      description: Provisioning status changed
-      summary: Cloud event example for QoD provisioning status change to UNAVAILABLE due to NETWORK_TERMINATED
+    ASSIGNMENT_STATUS_CHANGED_EXAMPLE:
+      description: Assignment status changed
+      summary: Cloud event example for QoD assignment status change to UNAVAILABLE due to NETWORK_TERMINATED
       value:
         id: 83a0d986-0866-4f38-b8c0-fc65bfcda452
         source: https://api.example.com/qod-provisioning/v0.2/device-qos/123e4567-e89b-12d3-a456-426614174000
@@ -1180,6 +1179,6 @@ components:
         type: org.camaraproject.qod-provisioning.v0.status-changed
         time: "2021-12-12T00:00:00Z"
         data:
-          provisioningId: 123e4567-e89b-12d3-a456-426614174000
+          assignmentId: 123e4567-e89b-12d3-a456-426614174000
           status: UNAVAILABLE
           statusInfo: NETWORK_TERMINATED

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -1155,7 +1155,8 @@ components:
         statusInfo: NETWORK_TERMINATED
 
     PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
-      summary: QoD provisioning status is available
+      summary: QoS provisioning status is available
+
       description: Device is optional in responses and must not be provided if it was not provided in the request
       value:
         qosProfile: QOS_M

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -1107,7 +1107,7 @@ components:
       value:
         qosProfile: QOS_L
         sink: https://application-server.com/callback
-        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         status: REQUESTED
 
     ASSIGNMENT_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE:
@@ -1118,7 +1118,7 @@ components:
           phoneNumber: "+123456789"
         qosProfile: QOS_L
         sink: https://application-server.com/callback
-        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         status: REQUESTED
 
     ASSIGNMENT_AVAILABLE:
@@ -1134,7 +1134,7 @@ components:
           accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
           accessTokenType: bearer
-        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         startedAt: "2024-05-12T17:32:01Z"
         status: AVAILABLE
 
@@ -1149,7 +1149,7 @@ components:
           accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
           accessTokenType: bearer
-        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         startedAt: "2024-05-12T17:32:01Z"
         status: UNAVAILABLE
         statusInfo: NETWORK_TERMINATED
@@ -1165,7 +1165,7 @@ components:
           accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
           accessTokenType: bearer
-        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         startedAt: "2024-05-12T17:32:01Z"
         status: AVAILABLE
 
@@ -1179,6 +1179,6 @@ components:
         type: org.camaraproject.qod-provisioning.v0.status-changed
         time: "2021-12-12T00:00:00Z"
         data:
-          assignmentId: 123e4567-e89b-12d3-a456-426614174000
+          provisioningId: 123e4567-e89b-12d3-a456-426614174000
           status: UNAVAILABLE
           statusInfo: NETWORK_TERMINATED

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -214,6 +214,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProvisioningInfo"
               examples:
+                PROVISIONING_AVAILABLE:
+                  $ref: "#/components/examples/PROVISIONING_AVAILABLE"
                 PROVISIONING_UNAVAILABLE:
                   $ref: "#/components/examples/PROVISIONING_UNAVAILABLE"
                 PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
@@ -1119,8 +1121,8 @@ components:
         qosStatus: REQUESTED
 
     PROVISIONING_AVAILABLE:
-      summary: QoD provisioning status is available
-      description: The provisioning has become available and device disambiguation is required
+      summary: QoD provisioning status is available with device disambiguation
+      description: The provisioning has become available, but multiple device identifiers were provided and hence device disambiguation is required
       value:
         device:
           phoneNumber: "+123456789"

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -325,8 +325,8 @@ paths:
               examples:
                 PROVISIONING_AVAILABLE:
                   $ref: "#/components/examples/PROVISIONING_AVAILABLE"
-                PROVISIONING_UNAVAILABLE:
-                  $ref: "#/components/examples/PROVISIONING_UNAVAILABLE"
+                ASSIGNMENT_UNAVAILABLE:
+                  $ref: "#/components/examples/ASSIGNMENT_UNAVAILABLE"
                 PROVISIONING_AVAILABLE_WITHOUT_DEVICE:
                   $ref: "#/components/examples/PROVISIONING_AVAILABLE_WITHOUT_DEVICE"
         "400":

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -1101,24 +1101,24 @@ components:
                 message: Rate limit reached.
 
   examples:
-    PROVISIONING_CREATION_EXAMPLE:
-      summary: Successful provisioning creation without device in the provisioning details
-      description: Example response after a new QoS provisioning has been created using a 3-legged access token, or possibly a single device identifier
+    ASSIGNMENT_CREATION_EXAMPLE:
+      summary: Successful assignment creation without device in the assignment details
+      description: Example response after a new QoS profile assignment has been created using a 3-legged access token, or possibly a single device identifier
       value:
         qosProfile: QOS_L
         sink: https://application-server.com/callback
-        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         status: REQUESTED
 
-    PROVISIONING_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE:
-      summary: Successful provisioning creation with device in the provisioning details
-      description: Example response after a new QoS provisioning has been created using a 2-legged access token with multiple device identifiers, or possibly only a single device identifier
+    ASSIGNMENT_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE:
+      summary: Successful assignment creation with device in the assignment details
+      description: Example response after a new QoS profile assignment has been created using a 2-legged access token with multiple device identifiers, or possibly only a single device identifier
       value:
         device:
           phoneNumber: "+123456789"
         qosProfile: QOS_L
         sink: https://application-server.com/callback
-        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         status: REQUESTED
 
     PROVISIONING_AVAILABLE:

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -14,7 +14,9 @@ info:
     Latency, throughput or priority requirements of the application mapped to relevant QoS profile values. The set of QoS Profiles that a network operator is offering may be retrieved via the `qos-profiles` API (cf. https://github.com/camaraproject/QualityOnDemand/) or will be agreed during the onboarding with the API service provider.
 
     * **Identifier for the device**:
-    At least one identifier for the device out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the network operator for the device, at the request time. After the provisioning request is accepted, the device may get different IP addresses, but the provisioning will still apply to the device that was identified during the request process. Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
+    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+    
+      Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Notification URL and token**:
     API consumers may provide a callback URL (`sink`) on which notifications about all status change events (eg. provisioning termination) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message. If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint.
@@ -162,6 +164,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ProvisioningInfo"
+              examples:
+                Successful Provisioning Creation:
+                  $ref: "#/components/examples/PROVISIONING_CREATION_EXAMPLE"
+                Successful Provisioning Creation With Device Disambiguation:
+                  $ref: "#/components/examples/PROVISIONING_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION"
         "400":
           $ref: "#/components/responses/TriggerProvisioning400"
         "401":
@@ -404,6 +411,10 @@ components:
         Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time the QoD provisioning was triggered.
 
       allOf:
+        - type: object
+          properties:
+            device:
+              $ref: "#/components/schemas/DeviceResponse"
         - $ref: "#/components/schemas/BaseProvisioningInfo"
         - type: object
           properties:
@@ -425,6 +436,10 @@ components:
     TriggerProvisioning:
       description: Attributes to request a new QoD provisioning
       allOf:
+        - type: object
+          properties:
+            device:
+              $ref: "#/components/schemas/Device"
         - $ref: "#/components/schemas/BaseProvisioningInfo"
 
     RetrieveProvisioningByDevice:
@@ -660,6 +675,16 @@ components:
         ipv6Address:
           $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
+
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
 
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
@@ -1009,18 +1034,11 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:
@@ -1080,6 +1098,26 @@ components:
                 message: Rate limit reached.
 
   examples:
+    PROVISIONING_CREATION_EXAMPLE:
+      summary: Successful provisioning creation
+      description: Example response after a new QoS provisioning has been created using a 3-legged access token or single device identifier
+      value:
+        qosProfile: QOS_L
+        sink: https://application-server.com/callback
+        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        qosStatus: REQUESTED
+
+    PROVISIONING_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION:
+      summary: Successful provisioning creation with device disambiguation
+      description: Example response after a new QoS provisioning has been created using multiple device identifiers
+      value:
+        device:
+          phoneNumber: "+123456789"
+        qosProfile: QOS_L
+        sink: https://application-server.com/callback
+        provisioningId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        qosStatus: REQUESTED
+
     PROVISIONING_AVAILABLE:
       summary: QoD provisioning status is available
       description: The provisioning has become available
@@ -1101,11 +1139,6 @@ components:
       summary: QoD provisioning status is unavailable
       description: The provisioning could not be created or is not active anymore
       value:
-        duration: 86400
-        device:
-          ipv4Address:
-            publicAddress: 203.0.113.0
-            publicPort: 59765
         qosProfile: QOS_L
         sink: https://application-server.com/callback
         sinkCredential:

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -110,12 +110,10 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/QosProfileDeviceResponse"
+                  $ref: "#/components/schemas/QosProfile"
               examples:
                 List of QoS Profiles:
                   $ref: "#/components/examples/LIST_OF_QOS_PROFILES"
-                List of QoS Profiles With Device Disambiguation:
-                  $ref: "#/components/examples/LIST_OF_QOS_PROFILES_WITH_DEVICE_DISAMBIGUATION"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -466,19 +464,6 @@ components:
         status:
           $ref: '#/components/schemas/QosProfileStatusEnum'
 
-    QosProfileDeviceResponse:
-      description: |
-        Response object for QoS Profiles for a given device. A device identifier is provided for disambiguation when multiple device identifiers were provided in the request.
-      allOf:
-        - type: object
-          properties:
-            device:
-              description: Disambiguates the device to which the session applies when multiple device identifiers were provided
-              allOf:
-                - $ref: "#/components/schemas/DeviceResponse"
-                - example: {"phoneNumber": "+123456789"}
-        - $ref: "#/components/schemas/QosProfile"
-
     Device:
       description: |
         End-user equipment able to connect to a mobile network. Examples of devices include smartphones or IoT sensors/actuators.
@@ -502,16 +487,6 @@ components:
         ipv6Address:
           $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
-
-    DeviceResponse:
-      description: |
-        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
-
-        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
-
-      allOf:
-        - $ref: "#/components/schemas/Device"
-        - maxProperties: 1
 
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
@@ -813,37 +788,6 @@ components:
       description: Example response when requesting a list of QoS profiles
       value:
         - name: "voice"
-          description: "QoS profile for high-quality interactive voice"
-          status: "ACTIVE"
-          targetMinUpstreamRate:
-            value: 100
-            unit: "kbps"
-          targetMinDownstreamRate:
-            value: 100
-            unit: "kbps"
-          minDuration:
-            value: 1
-            unit: "Days"
-          maxDuration:
-            value: 10
-            unit: "Days"
-          priority: 10
-          packetDelayBudget:
-            value: 50
-            unit: "Milliseconds"
-          jitter:
-            value: 5
-            unit: "Milliseconds"
-          packetErrorLossRate: 3
-          l4sQueueType: "non-l4s-queue"
-
-    LIST_OF_QOS_PROFILES_WITH_DEVICE_DISAMBIGUATION:
-      summary: A list of QoS profiles with a single entry and device disambiguation
-      description: Example response when requesting a list of QoS profiles with multiple device identifiers provided in the request
-      value:
-        - device:
-            phoneNumber: "+123456789"
-          name: "voice"
           description: "QoS profile for high-quality interactive voice"
           status: "ACTIVE"
           targetMinUpstreamRate:

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -823,11 +823,11 @@ components:
           description: "QoS profile for video streaming"
           status: "ACTIVE"
           targetMinUpstreamRate:
-           value: 100
-           unit: "kbps"
-         targetMinDownstreamRate:
-           value: 100,
-           unit: "kbps"
+            value: 100
+            unit: "kbps"
+          targetMinDownstreamRate:
+            value: 100,
+            unit: "kbps"
           minDuration:
             value: 1
             unit: "Days"
@@ -853,11 +853,11 @@ components:
           description: "QoS profile for video streaming"
           status: "ACTIVE"
           targetMinUpstreamRate:
-           value: 100
-           unit: "kbps"
-         targetMinDownstreamRate:
-           value: 100,
-           unit: "kbps"
+            value: 100
+            unit: "kbps"
+          targetMinDownstreamRate:
+            value: 100,
+            unit: "kbps"
           minDuration:
             value: 1
             unit: "Days"

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -83,6 +83,7 @@ paths:
         **NOTES:**
         - The access token may be either a 2-legged or 3-legged access token.
         - If the access token is 3-legged, all returned QoS Profiles will be available to the subject (device) associated with the access token.
+        - If the access token is 2-legged and a device filter is provided, all returned QoS Profiles will be available to that device. If multiple device identifiers are provided within the device property, only QoS Profiles available to the device identified by one of those identifiers will be returned, chosen by the implementation.
         - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET. Additionally, this call may include complex data structures.
           [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/r2.3/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
 

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -83,7 +83,7 @@ paths:
         **NOTES:**
         - The access token may be either a 2-legged or 3-legged access token.
         - If the access token is 3-legged, all returned QoS Profiles will be available to the subject (device) associated with the access token.
-        - If the access token is 2-legged and a device filter is provided, all returned QoS Profiles will be available to that device. If multiple device identifiers are provided within the device property, only QoS Profiles available to the device identified by one of those identifiers will be returned, chosen by the implementation.
+        - If the access token is 2-legged and a device filter is provided, all returned QoS Profiles will be available to that device. If multiple device identifiers are provided within the device property, only QoS Profiles available to the device identifier chosen by the implementation will be returned, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
         - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET. Additionally, this call may include complex data structures.
           [CAMARA API Design Guidelines](https://github.com/camaraproject/Commonalities/blob/r2.3/documentation/API-design-guidelines.md#post-or-get-for-transferring-sensitive-or-complex-data)
 

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -819,7 +819,7 @@ components:
             value: 100
             unit: "kbps"
           targetMinDownstreamRate:
-            value: 100,
+            value: 100
             unit: "kbps"
           minDuration:
             value: 1
@@ -850,7 +850,7 @@ components:
             value: 100
             unit: "kbps"
           targetMinDownstreamRate:
-            value: 100,
+            value: 100
             unit: "kbps"
           minDuration:
             value: 1

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -751,17 +751,10 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -110,7 +110,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/QosProfile"
+                  $ref: "#/components/schemas/QosProfileDeviceResponse"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -461,6 +461,19 @@ components:
         status:
           $ref: '#/components/schemas/QosProfileStatusEnum'
 
+    QosProfileDeviceResponse:
+      description: |
+        Response object for QoS Profiles for a given device. A device identifier is provided for disambiguation when multiple device identifiers were provided in the request.
+      allOf:
+        - type: object
+          properties:
+            device:
+              description: Disambiguates the device to which the session applies when multiple device identifiers were provided
+              allOf:
+                - $ref: "#/components/schemas/DeviceResponse"
+                - example: {"phoneNumber": "+123456789"}
+        - $ref: "#/components/schemas/QosProfile
+
     Device:
       description: |
         End-user equipment able to connect to a mobile network. Examples of devices include smartphones or IoT sensors/actuators.
@@ -484,7 +497,16 @@ components:
         ipv6Address:
           $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
-      maxProperties: 4
+
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
 
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -111,6 +111,11 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/QosProfileDeviceResponse"
+              examples:
+                List of QoS Profiles:
+                  $ref: "#/components/examples/LIST_OF_QOS_PROFILES"
+                List of QoS Profiles With Device Disambiguation:
+                  $ref: "#/components/examples/LIST_OF_QOS_PROFILES_WITH_DEVICE_DISAMBIGUATION"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -808,3 +813,63 @@ components:
                 status: 429
                 code: TOO_MANY_REQUESTS
                 message: Rate limit reached.
+
+  examples:
+    LIST_OF_QOS_PROFILES:
+      summary: A list of QoS profiles with a single entry
+      description: Example response when requesting a list of QoS profiles
+      value:
+        - name: "voice"
+          description: "QoS profile for video streaming"
+          status: "ACTIVE"
+          targetMinUpstreamRate:
+           value: 100
+           unit: "kbps"
+         targetMinDownstreamRate:
+           value: 100,
+           unit: "kbps"
+          minDuration:
+            value: 1
+            unit: "Days"
+          maxDuration:
+            value: 10
+            unit: "Days"
+          priority: 10
+          packetDelayBudget:
+            value: 50
+            unit: "Milliseconds"
+          jitter:
+            value: 5
+            unit: "Milliseconds"
+          packetErrorLossRate: 3
+          l4sQueueType: "non-l4s-queue"
+
+    LIST_OF_QOS_PROFILES_WITH_DEVICE_DISAMBIGUATION:
+      summary: A list of QoS profiles with a single entry and device disambiguation
+      description: Example response when requesting a list of QoS profiles with multiple device identifiers provided in the request
+      value:
+        - device:
+            phoneNumber: "+123456789"
+          description: "QoS profile for video streaming"
+          status: "ACTIVE"
+          targetMinUpstreamRate:
+           value: 100
+           unit: "kbps"
+         targetMinDownstreamRate:
+           value: 100,
+           unit: "kbps"
+          minDuration:
+            value: 1
+            unit: "Days"
+          maxDuration:
+            value: 10
+            unit: "Days"
+          priority: 10
+          packetDelayBudget:
+            value: 50
+            unit: "Milliseconds"
+          jitter:
+            value: 5
+            unit: "Milliseconds"
+          packetErrorLossRate: 3
+          l4sQueueType: "non-l4s-queue"

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -472,7 +472,7 @@ components:
               allOf:
                 - $ref: "#/components/schemas/DeviceResponse"
                 - example: {"phoneNumber": "+123456789"}
-        - $ref: "#/components/schemas/QosProfile
+        - $ref: "#/components/schemas/QosProfile"
 
     Device:
       description: |

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -820,7 +820,7 @@ components:
       description: Example response when requesting a list of QoS profiles
       value:
         - name: "voice"
-          description: "QoS profile for video streaming"
+          description: "QoS profile for high-quality interactive voice"
           status: "ACTIVE"
           targetMinUpstreamRate:
             value: 100
@@ -850,7 +850,8 @@ components:
       value:
         - device:
             phoneNumber: "+123456789"
-          description: "QoS profile for video streaming"
+          name: "voice"
+          description: "QoS profile for high-quality interactive voice"
           status: "ACTIVE"
           targetMinUpstreamRate:
             value: 100

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -203,6 +203,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SessionInfo"
+              examples:
+                Successful Session Creation:
+                  $ref: "#/components/examples/SESSION_CREATION_EXAMPLE"
         "400":
           $ref: "#/components/responses/CreateSessionBadRequest400"
         "401":
@@ -1449,6 +1452,22 @@ components:
                 message: Rate limit reached.
 
   examples:
+    SESSION_CREATION_EXAMPLE:
+      summary: QoS session has been created
+      description: Example response after a new QoS session has been created
+      value:
+        device:
+          phoneNumber: "+123456789"
+        applicationServer:
+          ipv4Address: 198.51.100.0/24
+        qosProfile: QOS_L
+        sink: https://application-server.com/notifications
+        sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        duration: 3600
+        startedAt: "2024-06-01T12:00:00Z"
+        expiresAt: "2024-06-01T13:00:00Z"
+        qosStatus: REQUESTED
+
     SESSION_AVAILABLE_EXAMPLE:
       summary: QoS session status is available
       description: QoS session info when status is available

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -26,7 +26,7 @@ info:
     Latency, throughput or priority requirements of the application mapped to relevant QoS profile values. The set of QoS Profiles that an API provider is offering may be retrieved via the `qos-profiles` API (cf. https://github.com/camaraproject/QualityOnDemand/) or will be agreed during the onboarding with the API provider.
 
     * **Identifier for the device**:
-    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
+    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response. Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Identifier for the application server**:
     IPv4 and/or IPv6 address of the application server (application backend)

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -26,7 +26,7 @@ info:
     Latency, throughput or priority requirements of the application mapped to relevant QoS profile values. The set of QoS Profiles that an API provider is offering may be retrieved via the `qos-profiles` API (cf. https://github.com/camaraproject/QualityOnDemand/) or will be agreed during the onboarding with the API provider.
 
     * **Identifier for the device**:
-    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone Number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session details. If only a single device identifier is provided, the implementation may or may not include the device identifier in the session details.
 
       Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
@@ -209,7 +209,7 @@ paths:
                 Successful Session Creation:
                   $ref: "#/components/examples/SESSION_CREATION_EXAMPLE"
                 Successful Session Creation With Device Disambiguation:
-                  $ref: "#/components/examples/SESSION_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION"
+                  $ref: "#/components/examples/SESSION_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE"
         "400":
           $ref: "#/components/responses/CreateSessionBadRequest400"
         "401":
@@ -423,7 +423,7 @@ paths:
                 RETRIEVE_SESSIONS_ONE_ITEM:
                   $ref: "#/components/examples/RETRIEVE_SESSIONS_EXAMPLE"
                 RETRIEVE_SESSIONS_ONE_ITEM_WITH_DEVICE_DISAMBIGUATION_REQUIRED:
-                  $ref: "#/components/examples/RETRIEVE_SESSIONS_EXAMPLE_WITH_DEVICE_DISAMBIGUATION"
+                  $ref: "#/components/examples/RETRIEVE_SESSIONS_EXAMPLE_WITH_DEVICE_RESPONSE"
                 RETRIEVE_SESSIONS_NO_ITEMS:
                   $ref: "#/components/examples/RETRIEVE_SESSIONS_EMPTY_EXAMPLE"
         "400":
@@ -1452,8 +1452,8 @@ components:
 
   examples:
     SESSION_CREATION_EXAMPLE:
-      summary: Successful session creation
-      description: Example response after a new QoS session has been created using a 3-legged access token or single device identifier
+      summary: Successful session creation with device not included in response
+      description: Example response after a new QoS session has been created using a 3-legged access token, or possibly a single device identifier
       value:
         applicationServer:
           ipv4Address: 198.51.100.0/24
@@ -1463,9 +1463,9 @@ components:
         duration: 3600
         qosStatus: REQUESTED
 
-    SESSION_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION:
-      summary: Successful session creation with device disambiguation
-      description: Example response after a new QoS session has been created using multiple device identifiers
+    SESSION_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE:
+      summary: Successful session creation with device included in response
+      description: Example response after a new QoS session has been created using a 2-legged access token with multiple device identifiers, or possibly only a single device identifier
       value:
         device:
           phoneNumber: "+123456789"
@@ -1534,9 +1534,9 @@ components:
           expiresAt: "2024-06-01T13:00:00Z"
           qosStatus: AVAILABLE
 
-    RETRIEVE_SESSIONS_EXAMPLE_WITH_DEVICE_DISAMBIGUATION:
-      summary: List of QoS sessions with device disambiguation
-      description: A single QoS session for the device is available but the device was specified using multiple device identifiers, and hence disambiguation is required
+    RETRIEVE_SESSIONS_EXAMPLE_WITH_DEVICE_RESPONSE:
+      summary: List of QoS sessions with device in the response
+      description: A single QoS session for the device is available and the device to which the sessions apply is listed in the response
       value:
         - device:
             phoneNumber: "+123456789"

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -27,7 +27,7 @@ info:
 
     * **Identifier for the device**:
     At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
-    
+
       Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Identifier for the application server**:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -1464,8 +1464,6 @@ components:
         sink: https://application-server.com/notifications
         sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         duration: 3600
-        startedAt: "2024-06-01T12:00:00Z"
-        expiresAt: "2024-06-01T13:00:00Z"
         qosStatus: REQUESTED
 
     SESSION_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION:
@@ -1480,8 +1478,6 @@ components:
         sink: https://application-server.com/notifications
         sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         duration: 3600
-        startedAt: "2024-06-01T12:00:00Z"
-        expiresAt: "2024-06-01T13:00:00Z"
         qosStatus: REQUESTED
 
     SESSION_AVAILABLE_EXAMPLE:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -502,11 +502,13 @@ components:
         Note that the device object is defined as optional and will only to be returned if provided in createSession. If more than one type of device identifier was provided, only one identifier will be returned (at implementation choice and with the original value provided in createSession).
         Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time of session creation.
       allOf:
-        - $ref: "#/components/schemas/BaseSessionInfo"
         - type: object
           properties:
             device:
               $ref: "#/components/schemas/DeviceResponse"
+        - $ref: "#/components/schemas/BaseSessionInfo"
+        - type: object
+          properties:
             sessionId:
               $ref: "#/components/schemas/SessionId"
             duration:
@@ -546,11 +548,13 @@ components:
     CreateSession:
       description: Attributes required to create a session
       allOf:
-        - $ref: "#/components/schemas/BaseSessionInfo"
         - type: object
           properties:
             device:
               $ref: "#/components/schemas/Device"
+        - $ref: "#/components/schemas/BaseSessionInfo"
+        - type: object
+          properties:
             duration:
               description: |
                 Requested session duration in seconds. Value may be explicitly limited for the QoS profile, as specified in the Qos Profile (see qos-profile API). Implementations can grant the requested session duration or set a different duration, based on network policies or conditions.

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -1455,7 +1455,7 @@ components:
 
   examples:
     SESSION_CREATION_EXAMPLE:
-      summary: QoS session has been created 
+      summary: Successful QoS session creation using a 3-legged access token or single device identifier
       description: Example response after a new QoS session has been created using a 3-legged access token or single device identifier
       value:
         applicationServer:
@@ -1469,7 +1469,7 @@ components:
         qosStatus: REQUESTED
 
     SESSION_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION:
-      summary: QoS session has been created
+      summary: Successful QoS session creation using multiple device identifiers
       description: Example response after a new QoS session has been created using multiple device identifiers
       value:
         device:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -1482,10 +1482,6 @@ components:
       description: QoS session info when status is available
       value:
         duration: 3600
-        device:
-          ipv4Address:
-            publicAddress: 203.0.113.0
-            publicPort: 59765
         applicationServer:
           ipv4Address: 198.51.100.0/24
         qosProfile: QOS_L
@@ -1500,10 +1496,6 @@ components:
       description: QoS session info when status is unavailable due to network termination
       value:
         duration: 2428
-        device:
-          ipv4Address:
-            publicAddress: 203.0.113.0
-            publicPort: 59765
         applicationServer:
           ipv4Address: 198.51.100.0/24
         qosProfile: QOS_L

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -471,8 +471,6 @@ components:
       description: Common attributes of a QoD session
       type: object
       properties:
-        device:
-          $ref: "#/components/schemas/Device"
         applicationServer:
           $ref: "#/components/schemas/ApplicationServer"
         devicePorts:
@@ -507,6 +505,8 @@ components:
         - $ref: "#/components/schemas/BaseSessionInfo"
         - type: object
           properties:
+            device:
+              $ref: "#/components/schemas/DeviceResponse"
             sessionId:
               $ref: "#/components/schemas/SessionId"
             duration:
@@ -549,6 +549,8 @@ components:
         - $ref: "#/components/schemas/BaseSessionInfo"
         - type: object
           properties:
+            device:
+              $ref: "#/components/schemas/Device"
             duration:
               description: |
                 Requested session duration in seconds. Value may be explicitly limited for the QoS profile, as specified in the Qos Profile (see qos-profile API). Implementations can grant the requested session duration or set a different duration, based on network policies or conditions.
@@ -833,6 +835,16 @@ components:
         ipv6Address:
           $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
+
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
 
     ApplicationServer:
       description: |
@@ -1306,18 +1318,11 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -1455,7 +1455,7 @@ components:
 
   examples:
     SESSION_CREATION_EXAMPLE:
-      summary: Successful QoS session creation using a 3-legged access token or single device identifier
+      summary: Successful Session Creation
       description: Example response after a new QoS session has been created using a 3-legged access token or single device identifier
       value:
         applicationServer:
@@ -1469,7 +1469,7 @@ components:
         qosStatus: REQUESTED
 
     SESSION_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION:
-      summary: Successful QoS session creation using multiple device identifiers
+      summary: Successful Session Creation With Device Disambiguation
       description: Example response after a new QoS session has been created using multiple device identifiers
       value:
         device:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -1521,8 +1521,8 @@ components:
           statusInfo: 'DURATION_EXPIRED'
 
     RETRIEVE_SESSIONS_EXAMPLE:
-      summary: List of QoS sessions for a specified device
-      description: A single QoS session for the device is available
+      summary: List of QoS sessions for the specified device
+      description: A single QoS session for the specified device is available
       value:
         - applicationServer:
             ipv4Address: 0.0.0.0/0
@@ -1535,8 +1535,8 @@ components:
           qosStatus: AVAILABLE
 
     RETRIEVE_SESSIONS_EXAMPLE_WITH_DEVICE_RESPONSE:
-      summary: List of QoS sessions with device in the response
-      description: A single QoS session for the device is available and the device to which the sessions apply is listed in the response
+      summary: List of QoS sessions for a specified device with the device in the response
+      description: A single QoS session for the device is available and the device to which the session applies is included in the response
       value:
         - device:
             phoneNumber: "+123456789"

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -26,7 +26,9 @@ info:
     Latency, throughput or priority requirements of the application mapped to relevant QoS profile values. The set of QoS Profiles that an API provider is offering may be retrieved via the `qos-profiles` API (cf. https://github.com/camaraproject/QualityOnDemand/) or will be agreed during the onboarding with the API provider.
 
     * **Identifier for the device**:
-    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response. Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
+    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+    
+    Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Identifier for the application server**:
     IPv4 and/or IPv6 address of the application server (application backend)

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -505,7 +505,10 @@ components:
         - type: object
           properties:
             device:
-              $ref: "#/components/schemas/DeviceResponse"
+              description: Disambiguates the device to which the session applies when multiple device identifiers were provided
+              allOf:
+                - $ref: "#/components/schemas/DeviceResponse"
+                - example: {"phoneNumber": "+123456789"}
         - $ref: "#/components/schemas/BaseSessionInfo"
         - type: object
           properties:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -206,6 +206,8 @@ paths:
               examples:
                 Successful Session Creation:
                   $ref: "#/components/examples/SESSION_CREATION_EXAMPLE"
+                Successful Session Creation With Device Disambiguation:
+                  $ref: "#/components/examples/SESSION_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION"
         "400":
           $ref: "#/components/responses/CreateSessionBadRequest400"
         "401":
@@ -1453,8 +1455,22 @@ components:
 
   examples:
     SESSION_CREATION_EXAMPLE:
+      summary: QoS session has been created 
+      description: Example response after a new QoS session has been created using a 3-legged access token or single device identifier
+      value:
+        applicationServer:
+          ipv4Address: 198.51.100.0/24
+        qosProfile: QOS_L
+        sink: https://application-server.com/notifications
+        sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        duration: 3600
+        startedAt: "2024-06-01T12:00:00Z"
+        expiresAt: "2024-06-01T13:00:00Z"
+        qosStatus: REQUESTED
+
+    SESSION_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION:
       summary: QoS session has been created
-      description: Example response after a new QoS session has been created
+      description: Example response after a new QoS session has been created using multiple device identifiers
       value:
         device:
           phoneNumber: "+123456789"

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -28,7 +28,7 @@ info:
     * **Identifier for the device**:
     At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
     
-    Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
+      Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Identifier for the application server**:
     IPv4 and/or IPv6 address of the application server (application backend)

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -1380,19 +1380,12 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
                       - QUALITY_ON_DEMAND.QOS_PROFILE_NOT_APPLICABLE
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -422,6 +422,8 @@ paths:
               examples:
                 RETRIEVE_SESSIONS_ONE_ITEM:
                   $ref: "#/components/examples/RETRIEVE_SESSIONS_EXAMPLE"
+                RETRIEVE_SESSIONS_ONE_ITEM_WITH_DEVICE_DISAMBIGUATION_REQUIRED:
+                  $ref: "#/components/examples/RETRIEVE_SESSIONS_EXAMPLE_WITH_DEVICE_DISAMBIGUATION"
                 RETRIEVE_SESSIONS_NO_ITEMS:
                   $ref: "#/components/examples/RETRIEVE_SESSIONS_EMPTY_EXAMPLE"
         "400":
@@ -1457,7 +1459,7 @@ components:
 
   examples:
     SESSION_CREATION_EXAMPLE:
-      summary: Successful Session Creation
+      summary: Successful session creation
       description: Example response after a new QoS session has been created using a 3-legged access token or single device identifier
       value:
         applicationServer:
@@ -1469,7 +1471,7 @@ components:
         qosStatus: REQUESTED
 
     SESSION_CREATION_EXAMPLE_WITH_DEVICE_DISAMBIGUATION:
-      summary: Successful Session Creation With Device Disambiguation
+      summary: Successful session creation with device disambiguation
       description: Example response after a new QoS session has been created using multiple device identifiers
       value:
         device:
@@ -1534,17 +1536,31 @@ components:
           statusInfo: 'DURATION_EXPIRED'
 
     RETRIEVE_SESSIONS_EXAMPLE:
-      summary: List of QoS sessions for the device
+      summary: List of QoS sessions for a specified device
       description: A single QoS session for the device is available
       value:
-        - duration: 3600
-          device:
+        - applicationServer:
+            ipv4Address: 0.0.0.0/0
+          qosProfile: QOS_L
+          sink: https://application-server.com/notifications
+          sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+          duration: 3600
+          startedAt: "2024-06-01T12:00:00Z"
+          expiresAt: "2024-06-01T13:00:00Z"
+          qosStatus: AVAILABLE
+
+    RETRIEVE_SESSIONS_EXAMPLE_WITH_DEVICE_DISAMBIGUATION:
+      summary: List of QoS sessions with device disambiguation
+      description: A single QoS session for the device is available but the device was specified using multiple device identifiers, and hence disambiguation is required
+      value:
+        - device:
             phoneNumber: "+123456789"
           applicationServer:
             ipv4Address: 0.0.0.0/0
           qosProfile: QOS_L
           sink: https://application-server.com/notifications
           sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+          duration: 3600
           startedAt: "2024-06-01T12:00:00Z"
           expiresAt: "2024-06-01T13:00:00Z"
           qosStatus: AVAILABLE

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -40,7 +40,7 @@ info:
     Duration (in seconds) for which the QoS session (between application client and application server) should be created. Limits for session duration can be set by the implementation for the QoS profile. The user may request a termination before its expiration.
 
      * **Notification URL and token**:
-    The API consumer may provide a callback URL (`sink`) on which notifications about all status change events (eg. provisioning termination) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message.
+    The API consumer may provide a callback URL (`sink`) on which notifications about all status change events (eg. session termination) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message.
     If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint. In the current version, `sinkCredential.credentialType` MUST be set to `ACCESSTOKEN` if provided.
 
     # API functionality

--- a/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
+++ b/code/Test_definitions/qod-provisioning-retrieveProvisioningByDevice.feature
@@ -131,19 +131,6 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation retrieveProvisioningByDev
         And the response property "$.message" contains a user-friendly text
 
 
-    # Several identifiers provided but they do not identify the same device
-    # This scenario may happen with 2-legged access tokens, which do not identify a device
-    @qod_provisioning_retrieveProvisioningByDevice_C01.08_device_identifiers_mismatch
-    Scenario: Device identifiers mismatch
-        Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And at least 2 types of device identifiers are supported by the implementation
-        And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-        When the HTTP "POST" request is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "IDENTIFIER_MISMATCH"
-        And the response property "$.message" contains a user friendly text
-
     # Errors 400
 
     @qod_provisioning_retrieveProvisioningByDevice_400.1_schema_not_compliant

--- a/code/Test_definitions/qod-provisioning-triggerProvisioning.feature
+++ b/code/Test_definitions/qod-provisioning-triggerProvisioning.feature
@@ -167,19 +167,6 @@ Feature: CAMARA QoD Provisioning API, vwip - Operation triggerProvisioning
         And the response property "$.message" contains a user-friendly text
 
 
-    # Several identifiers provided but they do not identify the same device
-    # This scenario may happen with 2-legged access tokens, which do not identify a device
-    @qod_provisioning_triggerProvisioning_C01.08_device_identifiers_mismatch
-    Scenario: Device identifiers mismatch
-        Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And at least 2 types of device identifiers are supported by the implementation
-        And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-        When the HTTP "POST" request is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "IDENTIFIER_MISMATCH"
-        And the response property "$.message" contains a user friendly text
-
     # Errors 400
 
     @qod_provisioning_triggerProvisioning_400.1_schema_not_compliant

--- a/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
@@ -174,19 +174,6 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
         And the response property "$.message" contains a user-friendly text
 
 
-    # Several identifiers provided but they do not identify the same device
-    # This scenario may happen with 2-legged access tokens, which do not identify a device
-    @qos_profiles_retrieveQoSProfiles_C01.08_device_identifiers_mismatch
-    Scenario: Device identifiers mismatch
-        Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And at least 2 types of device identifiers are supported by the implementation
-        And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-        When the HTTP "POST" request is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "IDENTIFIER_MISMATCH"
-        And the response property "$.message" contains a user friendly text
-
     # Errors 400
 
     @qos_profiles_retrieveQoSProfiles_400.1_schema_not_compliant

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -176,19 +176,6 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
         And the response property "$.message" contains a user-friendly text
 
 
-    # Several identifiers provided but they do not identify the same device
-    # This scenario may happen with 2-legged access tokens, which do not identify a device
-    @quality_on_demand_createSession_C01.08_device_identifiers_mismatch
-    Scenario: Device identifiers mismatch
-        Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And at least 2 types of device identifiers are supported by the implementation
-        And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-        When the HTTP "POST" request is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "IDENTIFIER_MISMATCH"
-        And the response property "$.message" contains a user friendly text
-
     # Errors 400
 
     @quality_on_demand_createSession_400.1_schema_not_compliant

--- a/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
+++ b/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
@@ -144,19 +144,6 @@ Feature: CAMARA Quality On Demand API, vwip - Operation retrieveSessionsByDevice
         And the response property "$.message" contains a user-friendly text
 
 
-    # Several identifiers provided but they do not identify the same device
-    # This scenario may happen with 2-legged access tokens, which do not identify a device
-    @quality_on_demand_retrieveSessionsByDevice_C01.08_device_identifiers_mismatch
-    Scenario: Device identifiers mismatch
-        Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And at least 2 types of device identifiers are supported by the implementation
-        And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-        When the HTTP "POST" request is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "IDENTIFIER_MISMATCH"
-        And the response property "$.message" contains a user friendly text
-
     # Errors 400
 
     @quality_on_demand_retrieveSessionsByDevice_400.1_schema_not_compliant


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities has removed the `IDENTIFIER_MISMATCH` error for Fall25. Instead, a device identifier should not normally be included in responses. It should only be included to disambiguate the identity of the device when:
- the endpoint is being accessed using a 2-legged access token; and
- the endpoint allows for a device identifier to be provided in the request; and
- the API consumer has included multiple device identifiers

The response then includes the device identifier that was used by the implementation

This PR:
- Updates documentation in each OAS
- Adds relevant example both for when device disambiguation is required, and when it is not required
- Uses `DeviceResponse` object to limit device identifiers in responses to exactly one
- Removes the IDENTIFIER_MISMATCH error code option from 422 responses and associated test cases

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #450 

#### Special notes for reviewers:
- Response examples could be improved in general. The "default" response examples created by the OAS viewers are generally not typical responses.
- For `qos-profiles`, I included an optional `device` parameter in all profiles returned by the `/retrieve-qos-profiles` endpoint. This is clumsy, but has the advantage of being a non-breaking change (for clients). A better solution would be to have a separate `device` parameter common to all profiles returned, but this would be a breaking change.
- I think all the `GET` and `DELETE` endpoints should never return a device identifier in the response, but haven't thought through all possible scenarios, so will raise this as a separate issue.

#### Changelog input

```
 release-note
 - Update documentation in each OAS
 - Add relevant example both for when device disambiguation is required, and when it is not required
 - Use DeviceResponse object to limit device identifiers in responses to exactly one
 - Remove the IDENTIFIER_MISMATCH error code option from 422 responses and associated test cases
```

#### Additional documentation 
None