### PR TITLE
Add reference booking Id for provisioning

### DIFF
--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -374,10 +374,10 @@ components:
         example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
 
   schemas:
-  
-  # This is an optional schema item, and is experimental and could be changed or removed in the future
+
+    # This is an optional schema item, and is experimental and could be changed or removed in the future
     BookingId:
-      description: | 
+      description: |
         ** Note** bookingId is optional and experimental and could be changed or removed in the future.
         If booking ID is present, provisioning of the device will happen against the booking done via QoSBooking API.
         If booking ID is present, requested qosProfile must match the qosProfile in the booking.
@@ -399,7 +399,7 @@ components:
         qosProfile:
           $ref: "#/components/schemas/QosProfileName"
         bookingId:
-          $ref: "#/components/schemas/BookingId"    
+          $ref: "#/components/schemas/BookingId"
         sink:
           type: string
           format: uri

--- a/code/API_definitions/qod-provisioning.yaml
+++ b/code/API_definitions/qod-provisioning.yaml
@@ -374,6 +374,17 @@ components:
         example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
 
   schemas:
+  
+  # This is an optional schema item, and is experimental and could be changed or removed in the future
+    BookingId:
+      description: | 
+        ** Note** bookingId is optional and experimental and could be changed or removed in the future.
+        If booking ID is present, provisioning of the device will happen against the booking done via QoSBooking API.
+        If booking ID is present, requested qosProfile must match the qosProfile in the booking.
+        Booking Identifier in UUID format.
+      type: string
+      format: uuid
+
     ProvisioningId:
       description: Provisioning Identifier in UUID format
       type: string
@@ -387,6 +398,8 @@ components:
           $ref: "#/components/schemas/Device"
         qosProfile:
           $ref: "#/components/schemas/QosProfileName"
+        bookingId:
+          $ref: "#/components/schemas/BookingId"    
         sink:
           type: string
           format: uri


### PR DESCRIPTION
#### What type of PR is this?


* enhancement/feature



#### What this PR does / why we need it:

This PR allows the user to reference an already existing booking for provisioning the device



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

1. Added BookingId Schema
2. Added bookingId property in BaseProvisioningInfo

```

#### Additional documentation 

This section can be blank.



```
docs

```
