### PR TITLE
Mismatch between test and API definition for networkAccessIdentifier …

### DIFF
--- a/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
@@ -120,11 +120,11 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
         And the response property "$.message" contains a user friendly text
         
         Examples:
-            | device_identifier          | oas_spec_schema                             |
-            | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-            | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
-            | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
-            | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
+            | device_identifier                | oas_spec_schema                             |
+            | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
+            | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+            | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
+            | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
   
     # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -45,7 +45,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
         And the response property "$.devicePorts" exists only if provided in the request body and with the same value
         And the response property "$.applicationServerPorts" exists only if provided in the request body and with the same value
         And the response property "$.sink" exists only if provided in the request body and with the same value
-        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatable for security concerns
+        # sinkCredential not explicitly mentioned to be returned if present, as this is debatable for security concerns
         And the response property "$.startedAt" exists only if "$.qosStatus" is "AVAILABLE" and the value is in the past
         And the response property "$.expiresAt" exists only if "$.qosStatus" is not "REQUESTED" and the value is later than "$.startedAt"
         And the response property "$.statusInfo" exists only if "$.qosStatus" is "UNAVAILABLE"
@@ -58,14 +58,14 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
         And the request property "$.qosProfile" is set to a valid QoS Profile as returned by QoS Profiles API
         And the request body property "$.duration" is set to a valid duration for the selected QoS profile
         And the request property "$.sink" is set to a URL where events can be monitored
-        And the request property "$.sinkCredentials.credentialType" is set to "ACCESSTOKEN"
-        And the request property "$.sinkCredentials.accessTokenType" is set to "bearer"
-        And the request property "$.sinkCredentials.accessToken" is set to a valid access token accepted by the events receiver
+        And the request property "$.sinkCredential.credentialType" is set to "ACCESSTOKEN"
+        And the request property "$.sinkCredential.accessTokenType" is set to "bearer"
+        And the request property "$.sinkCredential.accessToken" is set to a valid access token accepted by the events receiver
         When the request "createSession" is sent
         Then the response status code is 201
         # There is no specific limit defined for the process to end
         And an event is received at the address of the request property "$.sink"
-        And the event header "Authorization" is set to "Bearer: " + the value of the request property "$.sinkCredentials.accessToken"
+        And the event header "Authorization" is set to "Bearer: " + the value of the request property "$.sinkCredential.accessToken"
         And the event header "Content-Type" is set to "application/cloudevents+json"
         And the event body complies with the OAS schema at "/components/schemas/EventQosStatusChanged"
         # Additionally any event body has to comply with some constraints beyond the schema compliance
@@ -111,11 +111,11 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
         And the response property "$.message" contains a user friendly text
         
         Examples:
-            | device_identifier          | oas_spec_schema                             |
-            | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-            | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
-            | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
-            | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
+            | device_identifier                | oas_spec_schema                             |
+            | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
+            | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+            | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
+            | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
   
     # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.

--- a/code/Test_definitions/quality-on-demand-deleteSession.feature
+++ b/code/Test_definitions/quality-on-demand-deleteSession.feature
@@ -37,7 +37,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation deleteSession
         When the request "deleteSession" is sent
         Then the response status code is 204
         And an event is received at the address of the "$.sink" provided for createSession
-        And the event header "Authorization" is set to "Bearer: " + the value of the property "$.sinkCredentials.accessToken" provided for createSession
+        And the event header "Authorization" is set to "Bearer: " + the value of the property "$.sinkCredential.accessToken" provided for createSession
         And the event header "Content-Type" is set to "application/cloudevents+json"
         And the event body complies with the OAS schema at "/components/schemas/EventQosStatusChanged"
         # Additionally any event body has to comply with some constraints beyond the schema compliance

--- a/code/Test_definitions/quality-on-demand-getSession.feature
+++ b/code/Test_definitions/quality-on-demand-getSession.feature
@@ -36,7 +36,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation getSession
         And the response property "$.devicePorts" exists only if provided for createSession and with the same value
         And the response property "$.applicationServerPorts" exists only if provided for createSession and with the same value
         And the response property "$.sink" exists only if provided for createSession and with the same value
-        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatible for security concerns
+        # sinkCredential not explicitly mentioned to be returned if present, as this is debatible for security concerns
         And the response property "$.startedAt" exists only if "$.qosStatus" is "AVAILABLE" and the value is in the past
         And the response property "$.expiresAt" exists only if "$.qosStatus" is not "REQUESTED" and the value is later than "$.startedAt"
         And the response property "$.statusInfo" exists only if "$.qosStatus" is "UNAVAILABLE"

--- a/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
+++ b/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
@@ -40,7 +40,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation retrieveSessionsByDevice
         And the response property "$.devicePorts" exists only if provided for createSession and with the same value
         And the response property "$.applicationServerPorts" exists only if provided for createSession and with the same value
         And the response property "$.sink" exists only if provided for createSession and with the same value
-        # sinkCredentials not explicitly mentioned to be returned if present, as this is debatible for security concerns
+        # sinkCredential not explicitly mentioned to be returned if present, as this is debatible for security concerns
         And the response property "$.startedAt" exists only if "$.qosStatus" is "AVAILABLE" and the value is in the past
         And the response property "$.expiresAt" exists only if "$.qosStatus" is not "REQUESTED" and the value is later than "$.startedAt"
         And the response property "$.statusInfo" exists only if "$.qosStatus" is "UNAVAILABLE"
@@ -79,11 +79,11 @@ Feature: CAMARA Quality On Demand API, vwip - Operation retrieveSessionsByDevice
         And the response property "$.message" contains a user friendly text
         
         Examples:
-            | device_identifier          | oas_spec_schema                             |
-            | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-            | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
-            | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
-            | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
+            | device_identifier                | oas_spec_schema                             |
+            | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
+            | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+            | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
+            | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
   
     # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.


### PR DESCRIPTION
…and sinkCredential


#### What type of PR is this?

* bug
* tests


#### What this PR does / why we need it:

Fixes misalignment detected between spec and tests


#### Which issue(s) this PR fixes:

Fixes #461 

#### Special notes for reviewers:

Misalignments for qos-provisioning already addressed in #447 

