### PR TITLE
Reset versions in API and test definitions back to wip after r3.1

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -57,7 +57,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 1.1.0-rc.2
+  version: wip
   x-camara-commonalities: 0.6
 
 
@@ -66,7 +66,7 @@ externalDocs:
   url: https://github.com/camaraproject/QualityOnDemand
 
 servers:
-  - url: "{apiRoot}/qos-profiles/v1rc2"
+  - url: "{apiRoot}/qos-profiles/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -72,7 +72,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.3.0-rc.1
+  version: wip
   x-camara-commonalities: 0.6
 
 externalDocs:
@@ -80,7 +80,7 @@ externalDocs:
   url: https://github.com/camaraproject/QualityOnDemand
 
 servers:
-  - url: "{apiRoot}/qos-provisioning/v0.3rc1"
+  - url: "{apiRoot}/qos-provisioning/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -102,7 +102,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 1.1.0-rc.2
+  version: wip
   x-camara-commonalities: 0.6
 
 externalDocs:
@@ -110,7 +110,7 @@ externalDocs:
   url: https://github.com/camaraproject/QualityOnDemand
 
 servers:
-  - url: "{apiRoot}/quality-on-demand/v1rc2"
+  - url: "{apiRoot}/quality-on-demand/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/qos-profiles-getQosProfile.feature
+++ b/code/Test_definitions/qos-profiles-getQosProfile.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoS Profiles API, v1.1.0-rc.2 - Operation getQosProfile
+Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -11,7 +11,7 @@ Feature: CAMARA QoS Profiles API, v1.1.0-rc.2 - Operation getQosProfile
 
     Background: Common getQosProfile setup
         Given an environment at "apiRoot"
-        And the resource "qos-profiles/v1rc2/qos-profiles/{name}"
+        And the resource "qos-profiles/vwip/qos-profiles/{name}"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
         And the path param "name" is set by default to a existing QoS profile name

--- a/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoS Profiles API, v1.1.0-rc.2 - Operation retrieveQoSProfiles
+Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -15,7 +15,7 @@ Feature: CAMARA QoS Profiles API, v1.1.0-rc.2 - Operation retrieveQoSProfiles
 
     Background: Common retrieveQoSProfiles setup
         Given an environment at "apiRoot"
-        And the resource "qos-profiles/v1rc2/retrieve-qos-profiles"
+        And the resource "qos-profiles/vwip/retrieve-qos-profiles"
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/qos-provisioning-createQosAssignment.feature
+++ b/code/Test_definitions/qos-provisioning-createQosAssignment.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoS Provisioning API, v0.3.0-rc.1 - Operation createQosAssignment
+Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -15,7 +15,7 @@ Feature: CAMARA QoS Provisioning API, v0.3.0-rc.1 - Operation createQosAssignmen
 
     Background: Common createQosAssignment setup
         Given an environment at "apiRoot"
-        And the resource "/qos-provisioning/v0.3rc1/qos-assignments"
+        And the resource "/qos-provisioning/vwip/qos-assignments"
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/qos-provisioning-getQosAssignmentByDevice.feature
+++ b/code/Test_definitions/qos-provisioning-getQosAssignmentByDevice.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoS Provisioning API, v0.3.0-rc.1 - Operation getQosAssignmentByDevice
+Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentByDevice
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -16,7 +16,7 @@ Feature: CAMARA QoS Provisioning API, v0.3.0-rc.1 - Operation getQosAssignmentBy
 
     Background: Common getQosAssignmentByDevice setup
         Given an environment at "apiRoot"
-        And the resource "/qos-provisioning/v0.3rc1/retrieve-qos-assignment"                                                              |
+        And the resource "/qos-provisioning/vwip/retrieve-qos-assignment"                                                              |
         And the header "Content-Type" is set to "application/json"
         # Unless indicated otherwise the QoS assignment must be created by the same API client given in the access token
         And the header "Authorization" is set to a valid access token granted to the same client that created the QoS assignment

--- a/code/Test_definitions/qos-provisioning-getQosAssignmentById.feature
+++ b/code/Test_definitions/qos-provisioning-getQosAssignmentById.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoS Provisioning API, v0.3.0-rc.1 - Operation getQosAssignmentById
+Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentById
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -12,7 +12,7 @@ Feature: CAMARA QoS Provisioning API, v0.3.0-rc.1 - Operation getQosAssignmentBy
 
     Background: Common getQosAssignmentById setup
         Given an environment at "apiRoot"
-        And the resource "/qos-provisioning/v0.3rc1/qos-assignments/{assignmentId}"                                                              |
+        And the resource "/qos-provisioning/vwip/qos-assignments/{assignmentId}"                                                              |
         # Unless indicated otherwise the QoS assignment must be created by the same API client given in the access token
         And the header "Authorization" is set to a valid access token granted to the same client that created the QoS assignment
         And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/qos-provisioning-revokeQosAssignment.feature
+++ b/code/Test_definitions/qos-provisioning-revokeQosAssignment.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoS Provisioning API, v0.3.0-rc.1 - Operation revokeQosAssignment
+Feature: CAMARA QoS Provisioning API, vwip - Operation revokeQosAssignment
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -13,7 +13,7 @@ Feature: CAMARA QoS Provisioning API, v0.3.0-rc.1 - Operation revokeQosAssignmen
 
     Background: Common revokeQosAssignment setup
         Given an environment at "apiRoot"
-        And the resource "/qos-provisioning/v0.3rc1/qos-assignments/{assignmentId}"
+        And the resource "/qos-provisioning/vwip/qos-assignments/{assignmentId}"
         # Unless indicated otherwise the QoS assignment must be created by the same API client given in the access token
         And the header "Authorization" is set to a valid access token granted to the same client that created the QoS assignment
         And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Quality On Demand API, v1.1.0-rc.2 - Operation createSession
+Feature: CAMARA Quality On Demand API, vwip - Operation createSession
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -16,7 +16,7 @@ Feature: CAMARA Quality On Demand API, v1.1.0-rc.2 - Operation createSession
 
     Background: Common createSession setup
         Given an environment at "apiRoot"
-        And the resource "/quality-on-demand/v1rc2/sessions"
+        And the resource "/quality-on-demand/vwip/sessions"
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/quality-on-demand-deleteSession.feature
+++ b/code/Test_definitions/quality-on-demand-deleteSession.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Quality On Demand API, v1.1.0-rc.2 - Operation deleteSession
+Feature: CAMARA Quality On Demand API, vwip - Operation deleteSession
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -13,7 +13,7 @@ Feature: CAMARA Quality On Demand API, v1.1.0-rc.2 - Operation deleteSession
 
     Background: Common deleteSession setup
         Given an environment at "apiRoot"
-        And the resource "/quality-on-demand/v1rc2/sessions/{sessionId}"
+        And the resource "/quality-on-demand/vwip/sessions/{sessionId}"
         # Unless indicated otherwise the QoD provisioning must be created by the same API client given in the access token
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/quality-on-demand-extendQosSessionDuration.feature
+++ b/code/Test_definitions/quality-on-demand-extendQosSessionDuration.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Quality On Demand API, v1.1.0-rc.2 - Operation extendQosSessionDuration
+Feature: CAMARA Quality On Demand API, vwip - Operation extendQosSessionDuration
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -12,7 +12,7 @@ Feature: CAMARA Quality On Demand API, v1.1.0-rc.2 - Operation extendQosSessionD
 
     Background: Common extendQosSessionDuration setup
         Given an environment at "apiRoot"
-        And the resource "/quality-on-demand/v1rc2/sessions/{sessionId}/extend"
+        And the resource "/quality-on-demand/vwip/sessions/{sessionId}/extend"
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/quality-on-demand-getSession.feature
+++ b/code/Test_definitions/quality-on-demand-getSession.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Quality On Demand API, v1.1.0-rc.2 - Operation getSession
+Feature: CAMARA Quality On Demand API, vwip - Operation getSession
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -11,7 +11,7 @@ Feature: CAMARA Quality On Demand API, v1.1.0-rc.2 - Operation getSession
 
     Background: Common getSession setup
         Given an environment at "apiRoot"
-        And the resource "/quality-on-demand/v1rc2/sessions/{sessionId}"
+        And the resource "/quality-on-demand/vwip/sessions/{sessionId}"
         # Unless indicated otherwise the session must be created by the same API client given in the access token
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
+++ b/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Quality On Demand API, v1.1.0-rc.2 - Operation retrieveSessionsByDevice
+Feature: CAMARA Quality On Demand API, vwip - Operation retrieveSessionsByDevice
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -15,7 +15,7 @@ Feature: CAMARA Quality On Demand API, v1.1.0-rc.2 - Operation retrieveSessionsB
 
     Background: Common retrieveSessionsByDevice setup
         Given an environment at "apiRoot"
-        And the resource "/quality-on-demand/v1rc2/retrieve-sessions"
+        And the resource "/quality-on-demand/vwip/retrieve-sessions"
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* repository management

#### What this PR does / why we need it:

Setting the version in API and test definitions back to wip after r3.1 to clearly indicate that any change done between r3.1 and r3.2 does not belong to neither of the releases. 

That will allow to address open issues with PRs without taking care of the version field.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # none (repository management)

#### Special notes for reviewers:

Good practice as done in the past (see for example https://github.com/camaraproject/QualityOnDemand/pull/421)
