### PR TITLE
Add error 422 QOS_PROVISIONING.QOS_PROFILE_NOT_APPLICABLE

### DIFF
--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -52,6 +52,8 @@ info:
 
     - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
 
+    - If the requested `qosProfile` exists but is currently not available or incompatible for the QoS assignment (e.g., its status is INACTIVE or DEPRECATED, or its characteristics are not compatible with QoS Provisioning service), then the server will return an error with the `422 QOS_PROVISIONING.QOS_PROFILE_NOT_APPLICABLE` error code.
+
     # Multi-SIM scenario handling
 
     In multi-SIM scenarios where more than one mobile device is associated with a phone number (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device to which the QoS profile should apply from that phone number. If the phone number is used as the device identifier when assigning a QoS profile in a multi-SIM scenario, the API may respond with an error, apply the QoS profile to all devices in the multi-SIM group, or apply the QoS profile to a single device in the multi-SIM group which may not be the intended device.
@@ -188,7 +190,7 @@ paths:
         "409":
           $ref: "#/components/responses/AssignmentConflict409"
         "422":
-          $ref: "#/components/responses/Generic422"
+          $ref: "#/components/responses/CreateAssignment422"
         "429":
           $ref: "#/components/responses/Generic429"
       security:
@@ -1073,7 +1075,61 @@ components:
               value:
                 status: 422
                 code: UNNECESSARY_IDENTIFIER
+                message: The device is already identified by the access token.ç
+
+    CreateAssignment422:
+      description: Unprocessable Content
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 422
+                  code:
+                    enum:
+                      - SERVICE_NOT_APPLICABLE
+                      - MISSING_IDENTIFIER
+                      - UNSUPPORTED_IDENTIFIER
+                      - UNNECESSARY_IDENTIFIER
+                      - QOS_PROVISIONING.QOS_PROFILE_NOT_APPLICABLE
+          examples:
+            GENERIC_422_SERVICE_NOT_APPLICABLE:
+              description: Service not applicable for the provided identifier
+              value:
+                status: 422
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not available for the provided identifier.
+            GENERIC_422_MISSING_IDENTIFIER:
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the access token
+              value:
+                status: 422
+                code: MISSING_IDENTIFIER
+                message: The device cannot be identified.
+            GENERIC_422_UNSUPPORTED_IDENTIFIER:
+              description: None of the provided identifiers is supported by the implementation
+              value:
+                status: 422
+                code: UNSUPPORTED_IDENTIFIER
+                message: The identifier provided is not supported.
+            GENERIC_422_UNNECESSARY_IDENTIFIER:
+              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
+              value:
+                status: 422
+                code: UNNECESSARY_IDENTIFIER
                 message: The device is already identified by the access token.
+            QOS_PROVISIONING_422_QOS_PROFILE_NOT_APPLICABLE:
+              description: The requested QoS Profile exists but cannot be used for the QoS assignment.
+              value:
+                status: 422
+                code: QOS_PROVISIONING.QOS_PROFILE_NOT_APPLICABLE
+                message: The requested QoS Profile is not compatible with the QoS Provisioning service.
 
     Generic429:
       description: Too Many Requests

--- a/code/Test_definitions/qos-provisioning-createQosAssignment.feature
+++ b/code/Test_definitions/qos-provisioning-createQosAssignment.feature
@@ -305,3 +305,17 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
         And the response property "$.status" is 409
         And the response property "$.code" is "CONFLICT"
         And the response property "$.message" contains a user friendly text
+
+    # Errors 422
+
+    @qos_provisioning_createQosAssignment_422.1_qos_profile_not_applicable
+    Scenario: QoS Profile not applicable for the QoS assignment
+        Given a valid testing device supported by the service, identified by the token or provided in the request body
+        And the requested QoS Profile exists but is not applicable for the QoS assignment
+        When the request "createQosAssignment" is sent
+        Then the response status code is 422
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response property "$.status" is 422
+        And the response property "$.code" is "QOS_PROVISIONING.QOS_PROFILE_NOT_APPLICABLE"
+        And the response property "$.message" contains a user friendly text


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Add an equivalent error to QoS Provisioning that already exists in QualityOnDemand, and it is equally necessary

#### Which issue(s) this PR fixes:

 

#### Special notes for reviewers:

Related to discussion in #475, but not a fix
To be included in Fall25 for coherence with QoD

#### Changelog input

```
- Added error 422 QOS_PROVISIONING.QOS_PROFILE_NOT_APPLICABLE

```
