### PR TITLE
[Quality-on-demand]: Remove unnecessary allOf from SessionInfo.device definition

### DIFF
--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -522,10 +522,9 @@ components:
         - type: object
           properties:
             device:
+              $ref: "#/components/schemas/DeviceResponse"
               description: Disambiguates the device to which the session applies when multiple device identifiers were provided
-              allOf:
-                - $ref: "#/components/schemas/DeviceResponse"
-                - example: {"phoneNumber": "+123456789"}
+              example: { "phoneNumber": "+123456789" }
         - $ref: "#/components/schemas/BaseSessionInfo"
         - type: object
           properties:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug
* correction


#### What this PR does / why we need it:

This PR removes an unnecessary allOf wrapper from the device property in the SessionInfo schema.
The current use of allOf causes OpenAPI code generators to create an additional synthetic class (SessionInfoAllOfDevice), leading to compilation errors and inconsistent model mappings.

By defining the property directly using a $ref, the generated models remain clean,


#### Which issue(s) this PR fixes:

Fixes #505


