### PR TITLE
[Added] Allow application servers to be identified by IP address list

### DIFF
--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -32,10 +32,8 @@ info:
 
     * **Identifier for the application server**:
     The domain name and/or IPv4 address(es) and/or IPv6 address(es) used by the application server (application backend). Domain names shall be expanded to a list of IP addresses using the network operator's own DNS service, and the QoS profile will apply to all IP packets with these IP addresses as source or destination address.
-    
+
     The application service provider should ensure, that the application clients use the network operator's own DNS service for resolving the application servers IP addresses. The application client should use the same application server IP address(es) as the network for a correction functioning of the feature.
-    
-    Note that application data flows of WebRTC (e.g. speech flow) cannot be described using FQDNs, as the IP addresses of the peer (e.g. a TURN server) is typically not based on a DNS resolution.
 
     * **App-Flow (between the application client and application server)**:
     The precise application data flow the developer wants to prioritize and have stable latency or throughput for. This flow is in the current API version determined by the identified device and the application server. And it can be further elaborated with details such as ports or port-ranges. Future version of the API might allow more detailed flow identification features.

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -878,7 +878,7 @@ components:
       description: |
         A server hosting backend applications to deliver some business logic to clients.
 
-        The developer must provide one or more of the following application server identifiers:
+        The API consumer must provide one or more of the following application server identifiers:
 
         * `domainName`
           - The domain name that the device may use to connect to the application server

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -912,6 +912,7 @@ components:
         oneOf:
           - format: ipv4
           - format: ipv6
+      uniqueItems: true
       minItems: 1
       maxItems: 16
 

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -31,7 +31,7 @@ info:
       Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Identifier for the application server**:
-    IPv4 and/or IPv6 address of the application server (application backend)
+    The domain name and/or IPv4 address(es) and/or IPv6 address(es) used by the application server (application backend). Domain names shall be expanded to a list of IP addresses using the network operator's own DNS service, and the QoS profile will apply to all IP addresses specified.
 
     * **App-Flow (between the application client and application server)**:
     The precise application data flow the developer wants to prioritize and have stable latency or throughput for. This flow is in the current API version determined by the identified device and the application server. And it can be further elaborated with details such as ports or port-ranges. Future version of the API might allow more detailed flow identification features.
@@ -876,12 +876,20 @@ components:
       description: |
         A server hosting backend applications to deliver some business logic to clients.
 
-        The developer can choose to provide the below specified device identifiers:
+        The developer must provide one or more of the following application server identifiers:
 
+        * `domainName`
         * `ipv4Address`
         * `ipv6Address`
+        
+        If more than one identifier is provided, the QoS profile shall apply to all application servers identified.
+
+        If the developer specifies a domain name, the API provider shall resolve that domain name to a list of IP addresses using the DNS service that the network operator provides for devices connected to their network. The QoS profile shall apply to all traffic using these IP addresses, which may include traffic for a different domain name that shares one or more of these IP addresses. Note that if the device itself uses a different DNS service, there is no guarantee that the QoS profile will apply to the IP addresses returned by that service for the specified domain name.
+        
       type: object
       properties:
+        domainName:
+          $ref: "#/components/schemas/ApplicationServerDomainName"
         ipv4Address:
           $ref: "#/components/schemas/ApplicationServerIpv4Address"
         ipv6Address:
@@ -939,6 +947,13 @@ components:
       type: string
       format: ipv6
       example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+
+    ApplicationServerDomainName:
+      type: string
+      format: hostname
+      example: "example.com"
+      description: |
+        The domain name used by the application server. The domain name must be resolvable using the DNS service provided by the network operator for devices connected to their network. It is expected that the domain name will usually be a fully qualified domain name (FQDN).
 
     ApplicationServerIpv4Address:
       type: string

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -879,8 +879,13 @@ components:
         The developer must provide one or more of the following application server identifiers:
 
         * `domainName`
+          - The domain name that the device may use to connect to the application server
+        * `ipAddresses`
+          - A list of IPv4 and/or IPv6 addresses that may be used by the application server
         * `ipv4Address`
+          - An IPv4 subnet
         * `ipv6Address`
+          - An IPv6 subnet
 
         If more than one identifier is provided, the QoS profile shall apply to all application servers identified.
 
@@ -890,11 +895,25 @@ components:
       properties:
         domainName:
           $ref: "#/components/schemas/ApplicationServerDomainName"
+        ipAddresses:
+          $ref: "#/components/schemas/ApplicationServerIPAddressList"
         ipv4Address:
           $ref: "#/components/schemas/ApplicationServerIpv4Address"
         ipv6Address:
           $ref: "#/components/schemas/ApplicationServerIpv6Address"
       minProperties: 1
+
+    ApplicationServerIPAddressList:
+          description: A list of IPv4 and/or IPv6 addresses that may be used by the application server
+          type: array
+          items:
+            description: An IP address that may be used by the application server
+            type: string
+            oneOf:
+              - format: ipv4
+              - format: ipv6
+          minItems: 1
+          maxItems: 16
 
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -916,7 +916,7 @@ components:
       items:
         description: An IP address that may be used by the application server
         type: string
-        oneOf:
+        anyOf:
           - format: ipv4
           - format: ipv6
       uniqueItems: true

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -881,11 +881,11 @@ components:
         * `domainName`
         * `ipv4Address`
         * `ipv6Address`
-        
+
         If more than one identifier is provided, the QoS profile shall apply to all application servers identified.
 
         If the developer specifies a domain name, the API provider shall resolve that domain name to a list of IP addresses using the DNS service that the network operator provides for devices connected to their network. The QoS profile shall apply to all traffic using these IP addresses, which may include traffic for a different domain name that shares one or more of these IP addresses. Note that if the device itself uses a different DNS service, there is no guarantee that the QoS profile will apply to the IP addresses returned by that service for the specified domain name.
-        
+
       type: object
       properties:
         domainName:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -31,7 +31,11 @@ info:
       Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Identifier for the application server**:
-    The domain name and/or IPv4 address(es) and/or IPv6 address(es) used by the application server (application backend). Domain names shall be expanded to a list of IP addresses using the network operator's own DNS service, and the QoS profile will apply to all IP addresses specified.
+    The domain name and/or IPv4 address(es) and/or IPv6 address(es) used by the application server (application backend). Domain names shall be expanded to a list of IP addresses using the network operator's own DNS service, and the QoS profile will apply to all IP packets with these IP addresses as source or destination address.
+    
+    The application service provider should ensure, that the application clients use the network operator's own DNS service for resolving the application servers IP addresses. The application client should use the same application server IP address(es) as the network for a correction functioning of the feature.
+    
+    Note that application data flows of WebRTC (e.g. speech flow) cannot be described using FQDNs, as the IP addresses of the peer (e.g. a TURN server) is typically not based on a DNS resolution.
 
     * **App-Flow (between the application client and application server)**:
     The precise application data flow the developer wants to prioritize and have stable latency or throughput for. This flow is in the current API version determined by the identified device and the application server. And it can be further elaborated with details such as ports or port-ranges. Future version of the API might allow more detailed flow identification features.

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -904,16 +904,16 @@ components:
       minProperties: 1
 
     ApplicationServerIPAddressList:
-          description: A list of IPv4 and/or IPv6 addresses that may be used by the application server
-          type: array
-          items:
-            description: An IP address that may be used by the application server
-            type: string
-            oneOf:
-              - format: ipv4
-              - format: ipv6
-          minItems: 1
-          maxItems: 16
+      description: A list of IPv4 and/or IPv6 addresses that may be used by the application server
+      type: array
+      items:
+        description: An IP address that may be used by the application server
+        type: string
+        oneOf:
+          - format: ipv4
+          - format: ipv6
+      minItems: 1
+      maxItems: 16
 
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -884,7 +884,7 @@ components:
 
         If more than one identifier is provided, the QoS profile shall apply to all application servers identified.
 
-        If the developer specifies a domain name, the API provider shall resolve that domain name to a list of IP addresses using the DNS service that the network operator provides for devices connected to their network. The QoS profile shall apply to all traffic using these IP addresses, which may include traffic for a different domain name that shares one or more of these IP addresses. Note that if the device itself uses a different DNS service, there is no guarantee that the QoS profile will apply to the IP addresses returned by that service for the specified domain name.
+        If the API consumer specifies a domain name, the API provider shall resolve that domain name to a list of IP addresses using the DNS service that the network operator provides for devices connected to their network. The QoS profile shall apply to all traffic using these IP addresses, which may include traffic for a different domain name that shares one or more of these IP addresses. Note that if the application client on the device uses a different DNS service, there is no guarantee that the QoS profile will apply to the IP addresses returned by that service for the specified domain name.
 
       type: object
       properties:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -1547,7 +1547,7 @@ components:
       description: Example request using a 3-legged access token to identify the device and identifying the application server by IP address list
       value:
         applicationServer:
-          ipAddresses: ["198.51.100.0", "198.51.100.255", "2001:db8:85a3:8d3:1319:8a2e:370:7344"]
+          ipAddresses: ["198.51.100.0", "198.51.100.255"]
         qosProfile: QOS_L
         duration: 3600
         sink: https://application-server.com/notifications
@@ -1557,7 +1557,7 @@ components:
       description: Example response after a new QoS session has been created using a 3-legged access token (or possibly a single device identifier) when the application server was identified by IP address list
       value:
         applicationServer:
-          ipAddresses: ["198.51.100.0", "198.51.100.255", "2001:db8:85a3:8d3:1319:8a2e:370:7344"]
+          ipAddresses: ["198.51.100.0", "198.51.100.255"]
         qosProfile: QOS_L
         sink: https://application-server.com/notifications
         sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -922,16 +922,17 @@ components:
     ApplicationServerIPAddressList:
       description: A list of IPv4 and/or IPv6 addresses that may be used by the application server
       type: array
+      minItems: 1
+      maxItems: 16
       items:
         description: An IP address that may be used by the application server
         type: string
         maxLength: 39
+
 #        anyOf:
 #          - format: ipv4
 #          - format: ipv6
 #      uniqueItems: true
-      minItems: 1
-      maxItems: 16
 
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -929,11 +929,6 @@ components:
         type: string
         maxLength: 39
 
-#        anyOf:
-#          - format: ipv4
-#          - format: ipv6
-#      uniqueItems: true
-
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
       type: string

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -880,31 +880,26 @@ components:
       description: |
         A server hosting backend applications to deliver some business logic to clients.
 
-        The API consumer must provide one or more of the following application server identifiers:
+        The API consumer must identify the target application server either:
 
-        * `domainName`
-          - The domain name that the device may use to connect to the application server
-        * `ipAddresses`
-          - A list of IPv4 and/or IPv6 addresses that may be used by the application server
-        * `ipv4Address`
-          - An IPv4 subnet
-        * `ipv6Address`
-          - An IPv6 subnet
+        * by a list of individual IPv4 and/or IPv6 addresses:
+          - `ipAddresses`
+
+        * or by a single IPv4 subnet and/or single IPv6 subnet
+          - `ipv4Address`
+          - `ipv6Address`
 
         If more than one identifier is provided, the QoS profile shall apply to all application servers identified.
 
-        If the API consumer specifies a domain name, the API provider shall resolve that domain name to a list of IP addresses using the DNS service that the network operator provides for devices connected to their network. The QoS profile shall apply to all traffic using these IP addresses, which may include traffic for a different domain name that shares one or more of these IP addresses. Note that if the application client on the device uses a different DNS service, there is no guarantee that the QoS profile will apply to the IP addresses returned by that service for the specified domain name.
-
       type: object
       properties:
-        domainName:
-          $ref: "#/components/schemas/ApplicationServerDomainName"
-        ipAddresses:
-          $ref: "#/components/schemas/ApplicationServerIPAddressList"
-        ipv4Address:
-          $ref: "#/components/schemas/ApplicationServerIpv4Address"
-        ipv6Address:
-          $ref: "#/components/schemas/ApplicationServerIpv6Address"
+        oneOf:
+          - ipAddresses:
+              $ref: "#/components/schemas/ApplicationServerIPAddressList"
+          - ipv4Address:
+              $ref: "#/components/schemas/ApplicationServerIpv4Address"
+            ipv6Address:
+              $ref: "#/components/schemas/ApplicationServerIpv6Address"
       minProperties: 1
 
     ApplicationServerIPAddressList:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -218,7 +218,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/SessionInfo"
               examples:
-              examples:
                 Example 1:
                   $ref: "#/components/examples/EXAMPLE_1_CREATION_RESPONSE_3-LEGGED_ACCESS_TOKEN_IPv4_SUBNET"
                 Example 2:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -209,9 +209,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/SessionInfo"
               examples:
-                Successful Session Creation:
+                Successful_Session_Creation:
                   $ref: "#/components/examples/SESSION_CREATION_EXAMPLE"
-                Successful Session Creation With Device Disambiguation:
+                Successful_Session_Creation_Using_IP_Address_List:
+                  $ref: "#/components/examples/SESSION_CREATION_EXAMPLE_USING_IP_ADDRESS_LIST"
+                Successful_Session_Creation_With_Device_Disambiguation:
                   $ref: "#/components/examples/SESSION_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE"
         "400":
           $ref: "#/components/responses/CreateSessionBadRequest400"
@@ -912,6 +914,7 @@ components:
       items:
         description: An IP address that may be used by the application server
         type: string
+        maxLength: 39
         anyOf:
           - format: ipv4
           - format: ipv6
@@ -1512,6 +1515,18 @@ components:
       value:
         applicationServer:
           ipv4Address: 198.51.100.0/24
+        qosProfile: QOS_L
+        sink: https://application-server.com/notifications
+        sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        duration: 3600
+        qosStatus: REQUESTED
+
+    SESSION_CREATION_EXAMPLE_USING_IP_ADDRESS_LIST:
+      summary: Successful session creation with device not included in response
+      description: Example response after a new QoS session has been created using a 3-legged access token, or possibly a single device identifier
+      value:
+        applicationServer:
+          ipv4Addresses: ["198.51.100.0", "198.51.100.255", "2001:db8:85a3:8d3:1319:8a2e:370:7344"]
         qosProfile: QOS_L
         sink: https://application-server.com/notifications
         sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -28,9 +28,7 @@ info:
       Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Identifier for the application server**:
-    The domain name and/or IPv4 address(es) and/or IPv6 address(es) used by the application server (application backend). Domain names shall be expanded to a list of IP addresses using the network operator's own DNS service, and the QoS profile will apply to all IP packets with these IP addresses as source or destination address.
-
-    The application service provider should ensure, that the application clients use the network operator's own DNS service for resolving the application servers IP addresses. The application client should use the same application server IP address(es) as the network for a correction functioning of the feature.
+    A list or subnet of IPv4 and/or IPv6 addresses used by the application server (application backend)
 
     * **App-Flow (between the application client and application server)**:
     The precise application data flow the API consumer wants to prioritize and have stable latency or throughput for. This flow is in the current API version determined by the identified device and the application server. And it can be further elaborated with details such as ports or port-ranges. Future version of the API might allow more detailed flow identification features.

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -153,11 +153,20 @@ paths:
         - $ref: "#/components/parameters/x-correlator"
       requestBody:
         description: Parameters to create a new session
+        required: true
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/CreateSession"
-        required: true
+            examples:
+              Example 1:
+                $ref: "#/components/examples/EXAMPLE_1_CREATION_BODY_3-LEGGED_ACCESS_TOKEN_IPv4_SUBNET"
+              Example 2:
+                $ref: "#/components/examples/EXAMPLE_2_CREATION_BODY_3-LEGGED_ACCESS_TOKEN_IP_ADDRESS_LIST"
+              Example 3:
+                $ref: "#/components/examples/EXAMPLE_3_CREATION_BODY_2-LEGGED_ACCESS_TOKEN_IPv4_SUBNET"
+              Example 4:
+                $ref: "#/components/examples/EXAMPLE_4_CREATION_BODY_2-LEGGED_ACCESS_TOKEN_MULTIPLE_IDENTIFIERS_IPv4_SUBNET"
       callbacks:
         notifications:
           "{$request.body#/sink}":
@@ -209,12 +218,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/SessionInfo"
               examples:
-                Successful_Session_Creation:
-                  $ref: "#/components/examples/SESSION_CREATION_EXAMPLE"
-                Successful_Session_Creation_Using_IP_Address_List:
-                  $ref: "#/components/examples/SESSION_CREATION_EXAMPLE_USING_IP_ADDRESS_LIST"
-                Successful_Session_Creation_With_Device_Disambiguation:
-                  $ref: "#/components/examples/SESSION_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE"
+              examples:
+                Example 1:
+                  $ref: "#/components/examples/EXAMPLE_1_CREATION_RESPONSE_3-LEGGED_ACCESS_TOKEN_IPv4_SUBNET"
+                Example 2:
+                  $ref: "#/components/examples/EXAMPLE_2_CREATION_RESPONSE_3-LEGGED_ACCESS_TOKEN_IP_ADDRESS_LIST"
+                Example 3:
+                  $ref: "#/components/examples/EXAMPLE_3_CREATION_RESPONSE_2-LEGGED_ACCESS_TOKEN_IPv4_SUBNET"
+                Example 4:
+                  $ref: "#/components/examples/EXAMPLE_4_CREATION_RESPONSE_2-LEGGED_ACCESS_TOKEN_MULTIPLE_IDENTIFIERS_IPv4_SUBNET"
         "400":
           $ref: "#/components/responses/CreateSessionBadRequest400"
         "401":
@@ -1509,9 +1521,19 @@ components:
                 message: Rate limit reached.
 
   examples:
-    SESSION_CREATION_EXAMPLE:
-      summary: Successful session creation with device not included in response
-      description: Example response after a new QoS session has been created using a 3-legged access token, or possibly a single device identifier
+    EXAMPLE_1_CREATION_BODY_3-LEGGED_ACCESS_TOKEN_IPv4_SUBNET:
+      summary: Session creation example 1
+      description: Example request using a 3-legged access token to identify the device and identifying the application server by IPv4 subnet
+      value:
+        applicationServer:
+          ipv4Address: 198.51.100.0/24
+        qosProfile: QOS_L
+        duration: 3600
+        sink: https://application-server.com/notifications
+
+    EXAMPLE_1_CREATION_RESPONSE_3-LEGGED_ACCESS_TOKEN_IPv4_SUBNET:
+      summary: Successful session creation example 1
+      description: Example response after a new QoS session has been created using a 3-legged access token (or possibly a single device identifier) when the application server was identified by IPv4 subnet
       value:
         applicationServer:
           ipv4Address: 198.51.100.0/24
@@ -1521,24 +1543,75 @@ components:
         duration: 3600
         qosStatus: REQUESTED
 
-    SESSION_CREATION_EXAMPLE_USING_IP_ADDRESS_LIST:
-      summary: Successful session creation with device not included in response
-      description: Example response after a new QoS session has been created using a 3-legged access token, or possibly a single device identifier
+    EXAMPLE_2_CREATION_BODY_3-LEGGED_ACCESS_TOKEN_IP_ADDRESS_LIST:
+      summary: Session creation example 2
+      description: Example request using a 3-legged access token to identify the device and identifying the application server by IP address list
       value:
         applicationServer:
-          ipv4Addresses: ["198.51.100.0", "198.51.100.255", "2001:db8:85a3:8d3:1319:8a2e:370:7344"]
+          ipAddresses: ["198.51.100.0", "198.51.100.255", "2001:db8:85a3:8d3:1319:8a2e:370:7344"]
+        qosProfile: QOS_L
+        duration: 3600
+        sink: https://application-server.com/notifications
+
+    EXAMPLE_2_CREATION_RESPONSE_3-LEGGED_ACCESS_TOKEN_IP_ADDRESS_LIST:
+      summary: Successful session creation example 2
+      description: Example response after a new QoS session has been created using a 3-legged access token (or possibly a single device identifier) when the application server was identified by IP address list
+      value:
+        applicationServer:
+          ipAddresses: ["198.51.100.0", "198.51.100.255", "2001:db8:85a3:8d3:1319:8a2e:370:7344"]
         qosProfile: QOS_L
         sink: https://application-server.com/notifications
         sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         duration: 3600
         qosStatus: REQUESTED
 
-    SESSION_CREATION_EXAMPLE_WITH_DEVICE_RESPONSE:
-      summary: Successful session creation with device included in response
-      description: Example response after a new QoS session has been created using a 2-legged access token with multiple device identifiers, or possibly only a single device identifier
+    EXAMPLE_3_CREATION_BODY_2-LEGGED_ACCESS_TOKEN_IPv4_SUBNET:
+      summary: Session creation example 3
+      description: Example request using a 2-legged access token to identify the device and identifying the application server by IPv4 subnet
       value:
         device:
           phoneNumber: "+123456789"
+        applicationServer:
+          ipv4Address: 198.51.100.0/24
+        qosProfile: QOS_L
+        duration: 3600
+        sink: https://application-server.com/notifications
+
+    EXAMPLE_3_CREATION_RESPONSE_2-LEGGED_ACCESS_TOKEN_IPv4_SUBNET:
+      summary: Successful session creation example 3
+      description: Example response after a new QoS session has been created using a 2-legged access token with a single device identifier
+      value:
+        applicationServer:
+          ipv4Address: 198.51.100.0/24
+        qosProfile: QOS_L
+        sink: https://application-server.com/notifications
+        sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        duration: 3600
+        qosStatus: REQUESTED
+
+    EXAMPLE_4_CREATION_BODY_2-LEGGED_ACCESS_TOKEN_MULTIPLE_IDENTIFIERS_IPv4_SUBNET:
+      summary: Session creation example 4
+      description: Example request using a 2-legged access token with multiple device identifiers, and identifying the application server by IPv4 subnet
+      value:
+        device:
+          phoneNumber: "+123456789"
+          ipv4Address:
+            publicAddress: "203.0.113.0"
+            publicPort: 59765
+        applicationServer:
+          ipv4Address: 198.51.100.0/24
+        qosProfile: QOS_L
+        duration: 3600
+        sink: https://application-server.com/notifications
+
+    EXAMPLE_4_CREATION_RESPONSE_2-LEGGED_ACCESS_TOKEN_MULTIPLE_IDENTIFIERS_IPv4_SUBNET:
+      summary: Successful session creation example 4
+      description: Example response after a new QoS session has been created using a 2-legged access token indicating which device identifier is being used for the QoS session
+      value:
+        device:
+          ipv4Address:
+            publicAddress: "203.0.113.0"
+            publicPort: 59765
         applicationServer:
           ipv4Address: 198.51.100.0/24
         qosProfile: QOS_L

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -902,32 +902,49 @@ components:
           - `ipv4Address`
           - `ipv6Address`
 
-        If more than one identifier is provided, the QoS profile shall apply to all application servers identified.
+        If multiple IP addresses are specified, the QoS profile shall apply to all application servers using any of these addresses by the identified device
 
       oneOf:
-        - type: object
-          required:
-            - ipAddresses
-          properties:
-            ipAddresses:
-              $ref: "#/components/schemas/ApplicationServerIPAddressList"
-        - type: object
-          minProperties: 1
-          properties:
-            ipv4Address:
-              $ref: "#/components/schemas/ApplicationServerIpv4Address"
-            ipv6Address:
-              $ref: "#/components/schemas/ApplicationServerIpv6Address"
+        - $ref: "#/components/schemas/ApplicationServerIpAddressList"
+        - $ref: "#/components/schemas/ApplicationServerIpAddressSubnets"
 
-    ApplicationServerIPAddressList:
+    ApplicationServerIpAddressSubnets:
+      description: An IPv4 and/or IPv6 subnet used by the application server
+      type: object
+      anyOf:
+        - required: [ipv4Address]
+        - required: [ipv6Address]
+      minProperties: 1
+      maxProperties: 2
+      additionalProperties: false
+      properties:
+        ipv4Address:
+          $ref: "#/components/schemas/ApplicationServerIpv4Address"
+        ipv6Address:
+          $ref: "#/components/schemas/ApplicationServerIpv6Address"
+
+    ApplicationServerIpAddressList:
+      description: A single property called ipAddresses which is a list of IPv4 and/or IPv6 addresses that may be used by the application server
+      type: object
+      required:
+        - ipAddresses
+      additionalProperties: false
+      properties:
+        ipAddresses:
+          $ref: "#/components/schemas/ApplicationServerIpAddressListType"
+
+    ApplicationServerIpAddressListType:
       description: A list of IPv4 and/or IPv6 addresses that may be used by the application server
       type: array
       minItems: 1
       maxItems: 16
       items:
-        description: An IP address that may be used by the application server
-        type: string
+        description: A single IP address that may be used by the application server
+        uniqueItems: true
         maxLength: 39
+        anyOf:
+          - $ref: "#/components/schemas/SingleIpv4Addr"
+          - $ref: "#/components/schemas/SingleIpv6Addr"
 
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
@@ -971,6 +988,12 @@ components:
       type: string
       format: ipv4
       example: "203.0.113.0"
+
+    SingleIpv6Addr:
+      description: A single IPv6 address with no subnet mask
+      type: string
+      format: ipv6
+      example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
 
     DeviceIpv6Address:
       description: |
@@ -1539,6 +1562,7 @@ components:
           ipAddresses:
             - "198.51.100.0"
             - "198.51.100.255"
+            - "2001:db8:85a3:8d3:1319:8a2e:370:7344"
         qosProfile: QOS_L
         duration: 3600
         sink: https://application-server.com/notifications
@@ -1551,6 +1575,7 @@ components:
           ipAddresses:
             - "198.51.100.0"
             - "198.51.100.255"
+            - "2001:db8:85a3:8d3:1319:8a2e:370:7344"
         qosProfile: QOS_L
         sink: https://application-server.com/notifications
         sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -981,12 +981,14 @@ components:
     SingleIpv4Addr:
       description: A single IPv4 address with no subnet mask
       type: string
+      maxLength: 15
       format: ipv4
       example: "203.0.113.0"
 
     SingleIpv6Addr:
       description: A single IPv6 address with no subnet mask
       type: string
+      maxLength: 39
       format: ipv6
       example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
 
@@ -1001,6 +1003,7 @@ components:
 
     ApplicationServerIpv4Address:
       type: string
+      maxLength: 18
       example: "198.51.100.0/24"
       description: |
         IPv4 address may be specified in form <address/mask> as:
@@ -1010,6 +1013,7 @@ components:
 
     ApplicationServerIpv6Address:
       type: string
+      maxLength: 43
       example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
       description: |
         IPv6 address may be specified in form <address/mask> as:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -900,7 +900,7 @@ components:
           - `ipv4Address`
           - `ipv6Address`
 
-        If multiple IP addresses are specified, the QoS profile shall apply to all application servers using any of these addresses by the identified device
+        If `ipAddresses` is specified, the QoS profile shall apply to traffic between the identified device and any of the listed application server IP addresses.
 
       oneOf:
         - $ref: "#/components/schemas/ApplicationServerIpAddressList"

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -896,7 +896,7 @@ components:
       oneOf:
         - type: object
           required:
-          - ipAddresses
+            - ipAddresses
           properties:
             ipAddresses:
               $ref: "#/components/schemas/ApplicationServerIPAddressList"

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -1536,7 +1536,9 @@ components:
       description: Example request using a 3-legged access token to identify the device and identifying the application server by IP address list
       value:
         applicationServer:
-          ipAddresses: ["198.51.100.0", "198.51.100.255"]
+          ipAddresses:
+            - "198.51.100.0"
+            - "198.51.100.255"
         qosProfile: QOS_L
         duration: 3600
         sink: https://application-server.com/notifications
@@ -1546,7 +1548,9 @@ components:
       description: Example response after a new QoS session has been created using a 3-legged access token (or possibly a single device identifier) when the application server was identified by IP address list
       value:
         applicationServer:
-          ipAddresses: ["198.51.100.0", "198.51.100.255"]
+          ipAddresses:
+            - "198.51.100.0"
+            - "198.51.100.255"
         qosProfile: QOS_L
         sink: https://application-server.com/notifications
         sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -898,7 +898,7 @@ components:
           properties:
             ipAddresses:
               $ref: "#/components/schemas/ApplicationServerIPAddressList"
-        - type object
+        - type: object
           minProperties: 1
           properties:
             ipv4Address:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -891,16 +891,20 @@ components:
 
         If more than one identifier is provided, the QoS profile shall apply to all application servers identified.
 
-      type: object
-      properties:
-        oneOf:
-          - ipAddresses:
+      oneOf:
+        - type: object
+          required:
+          - ipAddresses
+          properties:
+            ipAddresses:
               $ref: "#/components/schemas/ApplicationServerIPAddressList"
-          - ipv4Address:
+        - type object
+          minProperties: 1
+          properties:
+            ipv4Address:
               $ref: "#/components/schemas/ApplicationServerIpv4Address"
             ipv6Address:
               $ref: "#/components/schemas/ApplicationServerIpv6Address"
-      minProperties: 1
 
     ApplicationServerIPAddressList:
       description: A list of IPv4 and/or IPv6 addresses that may be used by the application server

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -28,7 +28,7 @@ info:
       Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Identifier for the application server**:
-    A list or subnet of IPv4 and/or IPv6 addresses used by the application server (application backend)
+    A set of IPv4 and/or IPv6 addresses or subnets used by the application server (application backend)
 
     * **App-Flow (between the application client and application server)**:
     The precise application data flow the API consumer wants to prioritize and have stable latency or throughput for. This flow is in the current API version determined by the identified device and the application server. And it can be further elaborated with details such as ports or port-ranges. Future version of the API might allow more detailed flow identification features.

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -926,10 +926,10 @@ components:
         description: An IP address that may be used by the application server
         type: string
         maxLength: 39
-        anyOf:
-          - format: ipv4
-          - format: ipv6
-      uniqueItems: true
+#        anyOf:
+#          - format: ipv4
+#          - format: ipv6
+#      uniqueItems: true
       minItems: 1
       maxItems: 16
 
@@ -984,13 +984,6 @@ components:
       type: string
       format: ipv6
       example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
-
-    ApplicationServerDomainName:
-      type: string
-      format: hostname
-      example: "example.com"
-      description: |
-        The domain name used by the application server. The domain name must be resolvable using the DNS service provided by the network operator for devices connected to their network. It is expected that the domain name will usually be a fully qualified domain name (FQDN).
 
     ApplicationServerIpv4Address:
       type: string

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -936,7 +936,6 @@ components:
       items:
         description: A single IP address that may be used by the application server
         uniqueItems: true
-        maxLength: 39
         anyOf:
           - $ref: "#/components/schemas/SingleIpv4Addr"
           - $ref: "#/components/schemas/SingleIpv6Addr"
@@ -988,7 +987,7 @@ components:
     SingleIpv6Addr:
       description: A single IPv6 address with no subnet mask
       type: string
-      maxLength: 39
+      maxLength: 45
       format: ipv6
       example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
 
@@ -1013,7 +1012,7 @@ components:
 
     ApplicationServerIpv6Address:
       type: string
-      maxLength: 43
+      maxLength: 49
       example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
       description: |
         IPv6 address may be specified in form <address/mask> as:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -911,9 +911,6 @@ components:
     ApplicationServerIpAddressSubnets:
       description: An IPv4 and/or IPv6 subnet used by the application server
       type: object
-      anyOf:
-        - required: [ipv4Address]
-        - required: [ipv6Address]
       minProperties: 1
       maxProperties: 2
       additionalProperties: false

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -929,13 +929,13 @@ components:
           $ref: "#/components/schemas/ApplicationServerIpAddressListType"
 
     ApplicationServerIpAddressListType:
-      description: A list of IPv4 and/or IPv6 addresses that may be used by the application server
+      description: A list of unique IPv4 and/or IPv6 addresses that may be used by the application server
       type: array
       minItems: 1
       maxItems: 16
+      uniqueItems: true
       items:
         description: A single IP address that may be used by the application server
-        uniqueItems: true
         anyOf:
           - $ref: "#/components/schemas/SingleIpv4Addr"
           - $ref: "#/components/schemas/SingleIpv6Addr"


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
Currently, application servers can only be identified by a contiguous set of IP addresses within a defined subnet. This PR allows application servers to be identified by a list of single IPv4 and IPv6 addresses.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #513 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Allow application servers to be identified by IP address list
```

#### Additional documentation 
None