### PR TITLE
docs(maintainers): align MAINTAINERS header with template

### DIFF
--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -1,4 +1,4 @@
-| Org                    | Name                 | GitHub Name        |
+| Org                    | Name                 | GitHub Username    |
 | -----------------------| -------------------- | ------------------ |
 | Deutsche Telekom AG | Herbert Damker | hdamker |
 | Ericsson | Emil Zhang | emil-cheung |


### PR DESCRIPTION
#### What type of PR is this?
documentation

#### What this PR does / why we need it:
Renames the `MAINTAINERS.MD` table header from `GitHub Name` to `GitHub Username`
to align with `Template_API_Repository`.

This PR intentionally does not change the maintainer list so issue #532 can stay open
until it is clarified whether the missing team member has joined.

#### Which issue(s) this PR fixes:
Refs #532

#### Special notes for reviewers:
This is a header-only documentation change.

#### Additional documentation

```text
docs
```
