### PR TITLE
Fix GitHub username for Emil Zhang

### DIFF
--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -1,7 +1,7 @@
 | Org                    | Name                 | GitHub Username    |
 | -----------------------| -------------------- | ------------------ |
 | Deutsche Telekom AG | Herbert Damker | hdamker |
-| Ericsson | Emil Zhang | emil-cheung |
+| Ericsson | Emil Zhang | emilcheung |
 | Orange | Sylvain Morel | SylMOREL |
 | Orange | Patrice Conil | patrice-conil |
 | Spry Fox Networks | Ramesh Shanmugasundaram | sfnuser |


### PR DESCRIPTION
Corrected GitHub username for Emil Zhang.


#### What type of PR is this?

Add one of the following kinds:
* correction

#### What this PR does / why we need it:

User account of Emil changed from emil-chueng to emilchueng 


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
