### PR TITLE
Remove redundant format: string from QosProfileName schema

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -403,7 +403,6 @@ components:
       example: voice
       minLength: 3
       maxLength: 256
-      format: string
       pattern: "^[a-zA-Z0-9_.-]+$"
 
     Rate:

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -587,7 +587,6 @@ components:
       example: QCI_1_voice
       minLength: 3
       maxLength: 256
-      format: string
       pattern: "^[a-zA-Z0-9_.-]+$"
 
     CloudEvent:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -760,7 +760,6 @@ components:
       example: voice
       minLength: 3
       maxLength: 256
-      format: string
       pattern: "^[a-zA-Z0-9_.-]+$"
 
     CloudEvent:


### PR DESCRIPTION
#### What type of PR is this?
* bug

#### What this PR does / why we need it:
`format: string` is a redundant string format and is not recognised by the [OpenAPI Format Registry](https://spec.openapis.org/registry/format/). Hence it should be removed.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #496

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Remove redundant format: string from QosProfileName schema
```

#### Additional documentation 
None