### PR TITLE
fix: add missing 'type' on CloudEvent and Status schemas

### DIFF
--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -591,6 +591,7 @@ components:
 
     CloudEvent:
       description: Event compliant with the CloudEvents specification
+      type: object
       required:
         - id
         - source
@@ -757,6 +758,7 @@ components:
         * `REQUESTED` - QoS profile assignment has been requested but is still being processed.
         * `AVAILABLE` - The requested QoS profile has been assigned to the device, and is active.
         * `UNAVAILABLE` - The QoS profile assignment request has been processed but is not active. `statusInfo` may provide additional information about the reason for the unavailability.
+      type: string
       enum:
         - REQUESTED
         - AVAILABLE

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -764,6 +764,7 @@ components:
 
     CloudEvent:
       description: Event compliant with the CloudEvents specification
+      type: object
       required:
         - id
         - source


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Adds three missing `type:` declarations flagged by CAMARA Validation rule S-016 (`camara-schema-type-check`):

- `code/API_definitions/qos-provisioning.yaml`: `type: object` on `CloudEvent`, `type: string` on `Status`
- `code/API_definitions/quality-on-demand.yaml`: `type: object` on `CloudEvent`

Three single-line additions. No other changes.

#### Which issue(s) this PR fixes:

Fixes #554

#### Special notes for reviewers:

This is a temporary fix. The durable solution is to refactor both API definitions to consume the canonical Commonalities common schemas via `$ref` into `code/common/CAMARA_event_common.yaml` (and `CAMARA_common.yaml`), as enabled by Commonalities r4.2 — removing the inlined `CloudEvent` copies entirely.

#### Changelog input

```
 release-note
Fix three S-016 validation findings: add missing 'type' declarations on CloudEvent (×2) and Status schemas.
```

#### Additional documentation 

This section can be blank.

```
docs

```
