### PR TITLE
chore(release-plan): set ICM dependency to r4.2

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -26,7 +26,7 @@ repository:
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
   commonalities_release: r4.3
-  identity_consent_management_release: r4.1
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

Sets the ICM dependency in `release-plan.yaml` to `r4.2`, the current ICM release for the Sync26 cycle (was `r4.1`).

#### Which issue(s) this PR fixes:

n/a — release-plan metadata only.

#### Special notes for reviewers:

None.

#### Changelog input

```
 release-note
 No changelog needed (release-plan metadata only).
```

#### Additional documentation

This section can be blank.
