### PR TITLE
Adapt qos-profiles API spec and tests to Commonalities r4.3 (0.8.0)

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -17,6 +17,7 @@ info:
 
     How QoS profiles are mapped to connectivity characteristics are subject to agreements between the API provider and the API consumer. Within the CAMARA project, you can find a sample for such a mapping of QoS profiles. [CAMARA QoS Profiles Mapping Table (REFERENCE DRAFT)](https://github.com/camaraproject/QualityOnDemand/blob/main/documentation/API_documentation/QoSProfile_Mapping_Table.md)
 
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
@@ -24,6 +25,7 @@ info:
     The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
     # Identifying the device from the access token
 
@@ -46,19 +48,27 @@ info:
     - Identify the intended device from a unique identifier for that device, such as its source IP address and port
     - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device, and use the secondary phone number to identify the intended device if available
 
+    <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses
 
-    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
 
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+    <!-- CAMARA:MANDATORY:additional-error-responses:END -->
+
+    <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+    # Request body strictness
+
+    This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.
+    <!-- CAMARA:MANDATORY:request-body-strictness:END -->
 
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.6
+  x-camara-commonalities: 0.8.0
 
 
 externalDocs:
@@ -114,6 +124,7 @@ paths:
             application/json:
               schema:
                 type: array
+                maxItems: 100
                 items:
                   $ref: "#/components/schemas/QosProfile"
               examples:
@@ -178,30 +189,17 @@ paths:
 components:
   securitySchemes:
     openId:
-      type: openIdConnect
-      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+      $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
 
   parameters:
     x-correlator:
-      name: x-correlator
-      in: header
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
+      $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
 
   headers:
     x-correlator:
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
+      $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
 
   schemas:
-    XCorrelator:
-      description: Value for the x-correlator
-      type: string
-      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
-      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
-
     QosProfile:
       description: |
         Data type with attributes of a QosProfile
@@ -213,6 +211,7 @@ components:
           description: |
             A description of the QoS profile.
           type: string
+          maxLength: 1024
           example: "QoS profile for video streaming"
         status:
           $ref: "#/components/schemas/QosProfileStatusEnum"
@@ -481,6 +480,7 @@ components:
     Availability:
       description: A list of countries, and optionally networks, for which the API provider makes the profile available
       type: array
+      maxItems: 250
       items:
         type: object
         required:
@@ -490,177 +490,33 @@ components:
             description: The two letter ISO 3166-2 country code for the country in which the QoS profile is available in at least one network
             type: string
             pattern: ^[A-Z]{2}$
+            maxLength: 2
             example: "GB"
           networks:
             description: A list of networks within the country for which the QoS profile is available from the API provider
             type: array
+            maxItems: 100
             items:
               description: The network identifier. For mobile networks, this is the PLMN Identifier (MCC + MNC), which is a 5 or 6 digit integer.
               type: string
+              maxLength: 6
               example: "23591"
             example: ["23591", "23415"]
         example: {"countryName": "GB", "networks": ["23591", "23415"]}
       example: [{"countryName": "GB", "networks": ["23591", "23415"]}, {"countryName": "DE", "networks": ["26202"]}]
 
     Device:
-      description: |
-        End-user equipment able to connect to a mobile network. Examples of devices include smartphones or IoT sensors/actuators.
-
-        The API consumer can choose to provide the below specified device identifiers:
-
-        * `ipv4Address`
-        * `ipv6Address`
-        * `phoneNumber`
-        NOTE1: the network operator might support only a subset of these options. The API consumer can provide multiple identifiers to be compatible across different operators. In this case the identifiers MUST belong to the same device.
-        NOTE2: as for this Commonalities release, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
-
-      type: object
-      properties:
-        phoneNumber:
-          $ref: "#/components/schemas/PhoneNumber"
-        networkAccessIdentifier:
-          $ref: "#/components/schemas/NetworkAccessIdentifier"
-        ipv4Address:
-          $ref: "#/components/schemas/DeviceIpv4Addr"
-        ipv6Address:
-          $ref: "#/components/schemas/DeviceIpv6Address"
-      minProperties: 1
-
-    NetworkAccessIdentifier:
-      description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
-      type: string
-      example: "123456789@domain.com"
-
-    PhoneNumber:
-      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
-      type: string
-      pattern: '^\+[1-9][0-9]{4,14}$'
-      example: "+123456789"
-
-    DeviceIpv4Addr:
-      type: object
-      description: |
-        The device should be identified by either the public (observed) IP address and port as seen by the application server, or the private (local) and any public (observed) IP addresses in use by the device (this information can be obtained by various means, for example from some DNS servers).
-
-        If the allocated and observed IP addresses are the same (i.e. NAT is not in use) then  the same address should be specified for both publicAddress and privateAddress.
-
-        If NAT64 is in use, the device should be identified by its publicAddress and publicPort, or separately by its allocated IPv6 address (field ipv6Address of the Device object)
-
-        In all cases, publicAddress must be specified, along with at least one of either privateAddress or publicPort, dependent upon which is known. In general, mobile devices cannot be identified by their public IPv4 address alone.
-      properties:
-        publicAddress:
-          $ref: "#/components/schemas/SingleIpv4Addr"
-        privateAddress:
-          $ref: "#/components/schemas/SingleIpv4Addr"
-        publicPort:
-          $ref: "#/components/schemas/Port"
-      anyOf:
-        - required: [publicAddress, privateAddress]
-        - required: [publicAddress, publicPort]
-      example:
-        {
-          "publicAddress": "203.0.113.0",
-          "publicPort": 59765
-        }
-
-    Port:
-      description: TCP or UDP port number
-      type: integer
-      minimum: 0
-      maximum: 65535
-
-    SingleIpv4Addr:
-      description: A single IPv4 address with no subnet mask
-      type: string
-      format: ipv4
-      example: "203.0.113.0"
-
-    DeviceIpv6Address:
-      description: |
-        The device should be identified by the observed IPv6 address, or by any single IPv6 address from within the subnet allocated to the device (e.g. adding ::0 to the /64 prefix).
-
-        The session shall apply to all IP flows between the device subnet and the specified application server, unless further restricted by the optional parameters devicePorts or applicationServerPorts.
-      type: string
-      format: ipv6
-      example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+      $ref: "../common/CAMARA_common.yaml#/components/schemas/Device"
 
     ErrorInfo:
-      description: Common schema for errors
-      type: object
-      properties:
-        status:
-          type: integer
-          description: HTTP response status code
-        code:
-          type: string
-          description: A human-readable code to describe the error
-        message:
-          type: string
-          description: A human-readable description of what the event represents
-      required:
-        - status
-        - code
-        - message
+      $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
 
   responses:
     Generic400:
-      description: Bad Request
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 400
-                  code:
-                    enum:
-                      - INVALID_ARGUMENT
-                      - OUT_OF_RANGE
-          examples:
-            GENERIC_400_INVALID_ARGUMENT:
-              description: Invalid Argument. Generic Syntax Exception
-              value:
-                status: 400
-                code: INVALID_ARGUMENT
-                message: Client specified an invalid argument, request body or query param.
-            GENERIC_400_OUT_OF_RANGE:
-              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
-              value:
-                status: 400
-                code: OUT_OF_RANGE
-                message: Client specified an invalid range.
+      $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
 
     Generic401:
-      description: Unauthorized
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 401
-                  code:
-                    enum:
-                      - UNAUTHENTICATED
-          examples:
-            GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated and a new authentication is required
-              value:
-                status: 401
-                code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
+      $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
 
     Generic403:
       description: Forbidden
@@ -715,37 +571,7 @@ components:
                 message: The specified resource is not found.
 
     GenericDevice404:
-      description: Not found
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 404
-                  code:
-                    enum:
-                      - NOT_FOUND
-                      - IDENTIFIER_NOT_FOUND
-          examples:
-            GENERIC_404_NOT_FOUND:
-              description: Resource is not found
-              value:
-                status: 404
-                code: NOT_FOUND
-                message: The specified resource is not found.
-            GENERIC_404_DEVICE_NOT_FOUND:
-              description: Device identifier not found
-              value:
-                status: 404
-                code: IDENTIFIER_NOT_FOUND
-                message: Device identifier not found.
+      $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
 
     Generic422:
       description: Unprocessable Content
@@ -788,37 +614,7 @@ components:
                 message: The device is already identified by the access token.
 
     Generic429:
-      description: Too Many Requests
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 429
-                  code:
-                    enum:
-                      - QUOTA_EXCEEDED
-                      - TOO_MANY_REQUESTS
-          examples:
-            GENERIC_429_QUOTA_EXCEEDED:
-              description: Request is rejected due to exceeding a business quota limit
-              value:
-                status: 429
-                code: QUOTA_EXCEEDED
-                message: Out of resource quota.
-            GENERIC_429_TOO_MANY_REQUESTS:
-              description: Access to the API has been temporarily blocked due to rate or spike arrest limits being reached
-              value:
-                status: 429
-                code: TOO_MANY_REQUESTS
-                message: Rate limit reached.
+      $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
 
   examples:
     LIST_OF_QOS_PROFILES:

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -428,6 +428,7 @@ components:
           example: 12
           format: int32
           minimum: 1
+          maximum: 2147483647
         unit:
           $ref: "#/components/schemas/TimeUnitEnum"
 
@@ -482,6 +483,7 @@ components:
       type: array
       maxItems: 250
       items:
+        description: A country, and optionally the networks within that country, for which the API provider makes the QoS profile available
         type: object
         required:
           - countryName

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -501,6 +501,7 @@ components:
             items:
               description: The network identifier. For mobile networks, this is the PLMN Identifier (MCC + MNC), which is a 5 or 6 digit integer.
               type: string
+              pattern: '^[0-9]{5,6}$'
               maxLength: 6
               example: "23591"
             example: ["23591", "23415"]

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -18,6 +18,7 @@ info:
     How QoS profiles are mapped to connectivity characteristics are subject to agreements between the API provider and the API consumer. Within the CAMARA project, you can find a sample for such a mapping of QoS profiles. [CAMARA QoS Profiles Mapping Table (REFERENCE DRAFT)](https://github.com/camaraproject/QualityOnDemand/blob/main/documentation/API_documentation/QoSProfile_Mapping_Table.md)
 
     <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
+    
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -106,7 +106,7 @@ paths:
             - qos-profiles:read
       operationId: retrieveQoSProfiles
       parameters:
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       requestBody:
         description: Parameters to query QoS Profiles for a given device
         content:
@@ -119,7 +119,7 @@ paths:
           description: Contains information about QoS Profiles
           headers:
             x-correlator:
-              $ref: '#/components/headers/x-correlator'
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -164,13 +164,13 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/QosProfileName"
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       responses:
         "200":
           description: Contains information about QoS Profiles
           headers:
             x-correlator:
-              $ref: '#/components/headers/x-correlator'
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -190,14 +190,6 @@ components:
   securitySchemes:
     openId:
       $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
-
-  parameters:
-    x-correlator:
-      $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
-
-  headers:
-    x-correlator:
-      $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
 
   schemas:
     QosProfile:
@@ -528,7 +520,7 @@ components:
       description: Forbidden
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
@@ -554,7 +546,7 @@ components:
       description: Not found
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
@@ -583,7 +575,7 @@ components:
       description: Unprocessable Content
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -18,7 +18,6 @@ info:
     How QoS profiles are mapped to connectivity characteristics are subject to agreements between the API provider and the API consumer. Within the CAMARA project, you can find a sample for such a mapping of QoS profiles. [CAMARA QoS Profiles Mapping Table (REFERENCE DRAFT)](https://github.com/camaraproject/QualityOnDemand/blob/main/documentation/API_documentation/QoSProfile_Mapping_Table.md)
 
     <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
-    
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
@@ -50,7 +49,6 @@ info:
     - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device, and use the secondary phone number to identify the intended device if available
 
     <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
-    
     # Additional CAMARA error responses
 
     The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
@@ -61,7 +59,6 @@ info:
     <!-- CAMARA:MANDATORY:additional-error-responses:END -->
 
     <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
-    
     # Request body strictness
 
     This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -212,6 +212,9 @@ components:
             A description of the QoS profile.
           type: string
           maxLength: 1024
+          # Excludes control characters (C0 except TAB/LF/CR, DEL, C1) so that
+          # multiline descriptions remain valid
+          pattern: '^[^\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]*$'
           example: "QoS profile for video streaming"
         status:
           $ref: "#/components/schemas/QosProfileStatusEnum"

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -60,6 +60,7 @@ info:
     <!-- CAMARA:MANDATORY:additional-error-responses:END -->
 
     <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+    
     # Request body strictness
 
     This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -18,6 +18,7 @@ info:
     How QoS profiles are mapped to connectivity characteristics are subject to agreements between the API provider and the API consumer. Within the CAMARA project, you can find a sample for such a mapping of QoS profiles. [CAMARA QoS Profiles Mapping Table (REFERENCE DRAFT)](https://github.com/camaraproject/QualityOnDemand/blob/main/documentation/API_documentation/QoSProfile_Mapping_Table.md)
 
     <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
+
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
@@ -49,6 +50,7 @@ info:
     - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device, and use the secondary phone number to identify the intended device if available
 
     <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
+
     # Additional CAMARA error responses
 
     The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
@@ -59,6 +61,7 @@ info:
     <!-- CAMARA:MANDATORY:additional-error-responses:END -->
 
     <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+
     # Request body strictness
 
     This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.

--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -50,6 +50,7 @@ info:
     - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device, and use the secondary phone number to identify the intended device if available
 
     <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
+    
     # Additional CAMARA error responses
 
     The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.

--- a/code/Test_definitions/qos-profiles-getQosProfile.feature
+++ b/code/Test_definitions/qos-profiles-getQosProfile.feature
@@ -7,16 +7,18 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
   # Testing assets:
   # * The name of an existing QoS profile
   #
-  # References to OAS spec schemas refer to schemas specified in qos-profiles.yaml
+  # References to OAS spec schemas refer to schemas specified in qos-profiles.yaml,
+  # unless the path points to "../common/CAMARA_common.yaml", in which case the
+  # schema is the one synced from CAMARA Commonalities.
 
   Background: Common getQosProfile setup
     Given an environment at "apiRoot"
     And the resource "/qos-profiles/vwip/qos-profiles/{name}"
     And the header "Authorization" is set to a valid access token
-    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+    And the header "x-correlator" complies with the schema at "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
     And the path param "name" is set by default to an existing QoS profile name
 
-  # Success scenarios
+  ############################ Happy Path Scenarios #############################################
 
   @qos_profiles_getQosProfile_01_generic_success_scenario
   Scenario: Common validations for any success scenario
@@ -31,9 +33,11 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
     And the response property "$.name" value is equal to path param "name"
     # TBC: Add additional constraints, such as max* properties must be higher than min* equivalent properties, etc
 
-  # Errors 400
+  ############################ Error Scenarios #############################################
 
-  @qos_profiles_getQosProfile_400.1_name_does_not_match_regex
+  # Syntax Error scenarios
+
+  @qos_profiles_getQosProfile_400.01_name_does_not_match_regex
   Scenario: Path parameter name doesn't match the defined regular expression
     Given path parameter "name" does not match the regular expression "^[a-zA-Z0-9_.-]+$"
     When the request "getQosProfile" is sent
@@ -44,7 +48,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @qos_profiles_getQosProfile_400.2_invalid_name_length
+  @qos_profiles_getQosProfile_400.02_invalid_name_length
   Scenario: Path parameter name has an invalid length
     Given path parameter "name" has a length not between 3 and 256
     When the request "getQosProfile" is sent
@@ -55,12 +59,23 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  @qos_profiles_getQosProfile_400.03_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
+    When the request "getQosProfile" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
+  # Service Error scenarios
+
+  ## Authentication/Authorization errors
+
   # Generic 401 errors
 
-  @qos_profiles_getQosProfile_401.1_no_authorization_header
+  @qos_profiles_getQosProfile_401.01_no_authorization_header
   Scenario: Error response for no header "Authorization"
     Given the header "Authorization" is not sent
-    And the request body is set to a valid request body
     When the request "getQosProfile" is sent
     Then the response status code is 401
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -70,10 +85,9 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
     And the response property "$.message" contains a user friendly text
 
   # In this case both codes could make sense depending on whether the access token can be refreshed or not
-  @qos_profiles_getQosProfile_401.2_expired_access_token
+  @qos_profiles_getQosProfile_401.02_expired_access_token
   Scenario: Error response for expired access token
     Given the header "Authorization" is set to an expired access token
-    And the request body is set to a valid request body
     When the request "getQosProfile" is sent
     Then the response status code is 401
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -82,10 +96,9 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @qos_profiles_getQosProfile_401.3_invalid_access_token
+  @qos_profiles_getQosProfile_401.03_invalid_access_token
   Scenario: Error response for invalid access token
     Given the header "Authorization" is set to an invalid access token
-    And the request body is set to a valid request body
     When the request "getQosProfile" is sent
     Then the response status code is 401
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -96,9 +109,9 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
 
   # Generic 403 errors
 
-  @qos_profiles_getQosProfile_403.1_missing_access_token_scope
+  @qos_profiles_getQosProfile_403.01_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope qos-profiles:read
+    Given the header "Authorization" is set to an access token that does not include scope "qos-profiles:read"
     When the request "getQosProfile" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -109,7 +122,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
 
   # Generic 404 errors
 
-  @qos_profiles_getQosProfile_404.1_not_found
+  @qos_profiles_getQosProfile_404.01_not_found
   Scenario: name of a non-existing QoS profile
     Given the path parameter "name" is set to a random string compliant with the pattern
     When the request "getQosProfile" is sent
@@ -118,4 +131,18 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+
+  # Generic 429 errors
+
+  @qos_profiles_getQosProfile_429.01_too_many_requests
+  # To test this scenario the environment has to be configured to reject requests reaching the threshold limit set.
+  Scenario: Request is rejected due to threshold policy
+    Given a valid request for "getQosProfile"
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the request "getQosProfile" is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/qos-profiles-getQosProfile.feature
+++ b/code/Test_definitions/qos-profiles-getQosProfile.feature
@@ -29,7 +29,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
-    And each item of the response array complies with the OAS schema at "/components/schemas/QosProfile"
+    And the response body complies with the OAS schema at "/components/schemas/QosProfile"
     And the response property "$.name" value is equal to path param "name"
     # TBC: Add additional constraints, such as max* properties must be higher than min* equivalent properties, etc
 

--- a/code/Test_definitions/qos-profiles-getQosProfile.feature
+++ b/code/Test_definitions/qos-profiles-getQosProfile.feature
@@ -66,6 +66,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation getQosProfile
     Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
 
   # Service Error scenarios
 

--- a/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
@@ -10,19 +10,21 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
   # * The name of an existing QoS profile
   # * If some QoS Profile is restricted for some devices, provide the QoS profile name and device
   # * A device object identifying a device commercialized by the implementation for which the service is not applicable, if any
-
-  # References to OAS spec schemas refer to schemas specified in qos-profiles.yaml
+  #
+  # References to OAS spec schemas refer to schemas specified in qos-profiles.yaml,
+  # unless the path points to "../common/CAMARA_common.yaml", in which case the
+  # schema is the one synced from CAMARA Commonalities.
 
   Background: Common retrieveQoSProfiles setup
     Given an environment at "apiRoot"
     And the resource "/qos-profiles/vwip/retrieve-qos-profiles"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
-    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+    And the header "x-correlator" complies with the schema at "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
     # Properties not explicitly overwritten in the Scenarios can take any values compliant with the schema
     And the request body is set by default to a request body compliant with the schema at "/components/schemas/QosProfileDeviceRequest"
 
-    # Success scenarios
+  ############################ Happy Path Scenarios #############################################
 
   @qos_profiles_retrieveQoSProfiles_01_generic_success_scenario
   Scenario: Common validations for any success scenario
@@ -96,7 +98,9 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body is []
 
-  # Common error scenarios for management of input parameter device
+  ############################ Error Scenarios #############################################
+
+  # Error scenarios for management of input parameter device (C01)
 
   @qos_profiles_retrieveQoSProfiles_C01.01_device_empty
   Scenario: The device value is an empty object
@@ -104,6 +108,8 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the request body property "$.device" is set to: {}
     When the HTTP "POST" request is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
@@ -114,16 +120,18 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
     When the HTTP "POST" request is sent
     Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
     Examples:
-      | device_identifier                | oas_spec_schema                             |
-      | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
-      | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
-      | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
-      | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
+      | device_identifier                | oas_spec_schema                                                         |
+      | $.device.phoneNumber             | ../common/CAMARA_common.yaml#/components/schemas/PhoneNumber             |
+      | $.device.ipv4Address             | ../common/CAMARA_common.yaml#/components/schemas/DeviceIpv4Address       |
+      | $.device.ipv6Address             | ../common/CAMARA_common.yaml#/components/schemas/DeviceIpv6Address       |
+      | $.device.networkAccessIdentifier | ../common/CAMARA_common.yaml#/components/schemas/NetworkAccessIdentifier |
 
   # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.
   @qos_profiles_retrieveQoSProfiles_C01.03_device_not_found
@@ -132,6 +140,8 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the request body property "$.device" is compliant with the schema but does not identify a valid device
     When the HTTP "POST" request is sent
     Then the response status code is 404
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 404
     And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
     And the response property "$.message" contains a user friendly text
@@ -142,6 +152,8 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the request body property "$.device" is set to a valid device
     When the HTTP "POST" request is sent
     Then the response status code is 422
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 422
     And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
     And the response property "$.message" contains a user-friendly text
@@ -153,6 +165,8 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the request body property "$.device" only includes device identifiers not supported by the implementation
     When the HTTP "POST" request is sent
     Then the response status code is 422
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 422
     And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
     And the response property "$.message" contains a user-friendly text
@@ -164,23 +178,26 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And a valid device, identified by the token or provided in the request body, for which the service is not applicable
     When the HTTP "POST" request is sent
     Then the response status code is 422
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 422
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user-friendly text
 
-  # Errors 400
+  # Syntax Error scenarios
 
-  @qos_profiles_retrieveQoSProfiles_400.1_schema_not_compliant
+  @qos_profiles_retrieveQoSProfiles_400.01_schema_not_compliant
   Scenario: Invalid Argument. Generic Syntax Exception
     Given the request body is set to any value which is not compliant with the schema at "/components/schemas/QosProfileDeviceRequest"
     When the request "retrieveQoSProfiles" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @qos_profiles_retrieveQoSProfiles_400.2_no_request_body
+  @qos_profiles_retrieveQoSProfiles_400.02_no_request_body
   Scenario: Missing request body
     Given the request body is not included
     When the request "retrieveQoSProfiles" is sent
@@ -191,9 +208,34 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  @qos_profiles_retrieveQoSProfiles_400.03_empty_request_body
+  # It happens when the request body is an empty object while at least one property is required by the schema
+  # NOTE: Recommended value for "$.message" (NOT NORMATIVE) is "Missing mandatory parameter(s)"
+  Scenario: Empty object as request body
+    Given the request body is set to {}
+    When the request "retrieveQoSProfiles" is sent
+    Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+  @qos_profiles_retrieveQoSProfiles_400.04_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
+    When the request "retrieveQoSProfiles" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
+  # Service Error scenarios
+
+  ## Authentication/Authorization errors
+
   # Generic 401 errors
 
-  @qos_profiles_retrieveQoSProfiles_401.1_no_authorization_header
+  @qos_profiles_retrieveQoSProfiles_401.01_no_authorization_header
   Scenario: Error response for no header "Authorization"
     Given the header "Authorization" is not sent
     And the request body is set to a valid request body
@@ -206,7 +248,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the response property "$.message" contains a user friendly text
 
   # In this case both codes could make sense depending on whether the access token can be refreshed or not
-  @qos_profiles_retrieveQoSProfiles_401.2_expired_access_token
+  @qos_profiles_retrieveQoSProfiles_401.02_expired_access_token
   Scenario: Error response for expired access token
     Given the header "Authorization" is set to an expired access token
     And the request body is set to a valid request body
@@ -218,7 +260,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @qos_profiles_retrieveQoSProfiles_401.3_invalid_access_token
+  @qos_profiles_retrieveQoSProfiles_401.03_invalid_access_token
   Scenario: Error response for invalid access token
     Given the header "Authorization" is set to an invalid access token
     And the request body is set to a valid request body
@@ -232,13 +274,27 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
 
   # Generic 403 errors
 
-  @qos_profiles_retrieveQoSProfiles_403.1_missing_access_token_scope
+  @qos_profiles_retrieveQoSProfiles_403.01_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope qos-profiles:read
+    Given the header "Authorization" is set to an access token that does not include scope "qos-profiles:read"
     When the request "retrieveQoSProfiles" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text
+
+  # Generic 429 errors
+
+  @qos_profiles_retrieveQoSProfiles_429.01_too_many_requests
+  # To test this scenario the environment has to be configured to reject requests reaching the threshold limit set.
+  Scenario: Request is rejected due to threshold policy
+    Given a valid request for "retrieveQoSProfiles"
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the request "retrieveQoSProfiles" is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
@@ -208,20 +208,11 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @qos_profiles_retrieveQoSProfiles_400.03_empty_request_body
-  # It happens when the request body is an empty object while at least one property is required by the schema
-  # NOTE: Recommended value for "$.message" (NOT NORMATIVE) is "Missing mandatory parameter(s)"
-  Scenario: Empty object as request body
-    Given the request body is set to {}
-    When the request "retrieveQoSProfiles" is sent
-    Then the response status code is 400
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response header "Content-Type" is "application/json"
-    And the response property "$.status" is 400
-    And the response property "$.code" is "INVALID_ARGUMENT"
-    And the response property "$.message" contains a user friendly text
+  # Scenario "empty_request_body" ({} => 400) does not apply to this operation:
+  # QosProfileDeviceRequest has no required properties, so an empty object is a
+  # valid request returning all profiles (see scenario 05_not_return_restricted_profiles)
 
-  @qos_profiles_retrieveQoSProfiles_400.04_invalid_x-correlator
+  @qos_profiles_retrieveQoSProfiles_400.03_invalid_x-correlator
   Scenario: Invalid x-correlator header
     Given the header "x-correlator" does not comply with the schema at "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
     When the request "retrieveQoSProfiles" is sent

--- a/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQoSProfiles.feature
@@ -219,6 +219,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
 
   # Service Error scenarios
 


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Adapts the `qos-profiles` API specification and its test definitions to [CAMARA Commonalities r4.3](https://github.com/camaraproject/Commonalities/releases/tag/r4.3) (Commonalities 0.8.0), using the analysis done by the Commonalities Working Group ([Analysis of Commonalities 0.8.0](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/789086209/Analysis+of+Commonalities+0.8.0)) and the [ConsentManagement #29](https://github.com/camaraproject/ConsentManagement/pull/29) alignment as references.

**API specification (`qos-profiles.yaml`):**
- Updated `x-camara-commonalities` from `0.6` to `0.8.0`.
- Replaced duplicated definitions with `$ref` into `code/common/CAMARA_common.yaml`: `openId` security scheme, `x-correlator` parameter/header, `Device`, `ErrorInfo`, and responses `Generic400`, `Generic401`, `Generic429`; `GenericDevice404` now references the common `Generic404` (identical code set).
- Removed the now-unused local schemas `XCorrelator`, `PhoneNumber`, `NetworkAccessIdentifier`, `DeviceIpv4Addr`, `SingleIpv4Addr`, `Port`, `DeviceIpv6Address` (rule S-211).
- Kept **local code-subset** responses where the common definition lists codes that do not apply to this API: `Generic403` (`PERMISSION_DENIED` only), `Generic404` (`NOT_FOUND` only, for `getQosProfile`), `Generic422` (`SERVICE_NOT_APPLICABLE`, `UNSUPPORTED_IDENTIFIER`, `UNNECESSARY_IDENTIFIER`).
- Added the mandatory `info.description` section markers (text copied as-is from `code/common/info-description-templates.yaml`): `authorization-and-authentication`, `additional-error-responses`, and the new `request-body-strictness`.
- Added `maxLength`/`maxItems` constraints (rules S-312 / S-309) to the remaining local schemas: `QosProfile.description`, `Availability` and its `networks` array, `countryName`, and the `retrieveQoSProfiles` 200 response array.

**Test definitions (both `.feature` files):**
- Aligned with the [r4.3 sample-service-template](https://github.com/camaraproject/Commonalities/blob/main/artifacts/testing/sample-service-template.feature): added `Happy Path Scenarios` / `Error Scenarios` banners and `Syntax Error` / `Service Error` subsections.
- Renumbered error-scenario tags to double-digit format (`400.01`, `401.01`, `403.01`, `404.01`, `429.01`, …).
- Added `429.01_too_many_requests` and `invalid_x-correlator` scenarios (and `400.03_empty_request_body` for `retrieveQoSProfiles`); added `x-correlator`/`Content-Type` response-header assertions to the device error scenarios.
- Updated schema references that moved to common (`XCorrelator`, `PhoneNumber`, `DeviceIpv4Address`, `DeviceIpv6Address`, `NetworkAccessIdentifier`) to point at `../common/CAMARA_common.yaml`.

#### Which issue(s) this PR fixes:

Fixes #573

#### Special notes for reviewers:

Two deliberate deviations from the generic Commonalities template, for your attention:

1. **`identifying-device-from-access-token` mandatory block not embedded verbatim.** The standard opt-in block states the `device` object "MUST be provided" with a two-legged token and defines a `422 MISSING_IDENTIFIER` case. In `qos-profiles`, however, `device` is an **optional filter** — `retrieveQoSProfiles` legitimately returns all profiles when no device is supplied, so `MISSING_IDENTIFIER` does not apply. The existing, accurate "Identifying the device from the access token" section (documenting the optional filter and the `422 UNNECESSARY_IDENTIFIER` behaviour) has been kept instead. This is compliant because the Appendix A block is opt-in.

2. **No `403.02_api_client_token_mismatch` scenario.** That template scenario targets resources created/managed by a specific API client. QoS Profiles are provider-defined, read-only resources with no per-client ownership, so the scenario does not apply to either operation.

Also: the `403`/`404`/`422` responses are intentionally kept as local code-subsets (rather than `$ref`-ing the common responses) because the common versions include additional codes (`INVALID_TOKEN_CONTEXT`, `IDENTIFIER_NOT_FOUND`, `MISSING_IDENTIFIER`) that are not applicable to these operations — the same selective approach taken in ConsentManagement #29.

The CHANGELOG and API Readiness Checklist are intentionally not modified in this PR (the changelog is generated from the changelog-input below at release time), matching the ConsentManagement #29 precedent.

#### Changelog input

```
 release-note
Aligned the QoS Profiles API and its test definitions with CAMARA Commonalities r4.3 (0.8.0): reuse common schemas/responses via $ref into code/common/, add S-309/S-312 constraints and mandatory info.description section markers, and align the test definitions with the r4.3 sample-service-template.
```

#### Additional documentation

This section can be blank.

```
docs

```
