### PR TITLE
docs: clarify create-time QoD unavailability

### DIFF
--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -133,7 +133,10 @@ paths:
         - a `QOS_STATUS_CHANGED` event notification with `qosStatus` as `AVAILABLE` after the network notifies that it has created the requested session, or
         - a `QOS_STATUS_CHANGED` event notification with `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED` after the network notifies that it has failed to provide the requested session.
 
-        A `QOS_STATUS_CHANGED` event notification with `qosStatus` as `UNAVAILABLE` will also be send if the network terminates the session before the requested duration expired
+        If the network already knows during session creation that it cannot provide the requested QoS, the `201` response MAY directly include
+        `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED`.
+
+        A `QOS_STATUS_CHANGED` event notification with `qosStatus` as `UNAVAILABLE` will also be sent if the network terminates the session before the requested duration expired
 
         **NOTES:**
         - In case of a `QOS_STATUS_CHANGED` event with `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED` the resources of the QoS session are not directly released, but will get deleted automatically at earliest 360 seconds after the event.
@@ -830,7 +833,7 @@ components:
       description: |
         Reason for the new `qosStatus`. Currently `statusInfo` is only applicable when `qosStatus` is 'UNAVAILABLE'.
         * `DURATION_EXPIRED` - Session terminated due to requested duration expired
-        * `NETWORK_TERMINATED` - Network terminated the session before the requested duration expired
+        * `NETWORK_TERMINATED` - Network terminated the session before the requested duration expired, or determined during session creation that the requested QoS session cannot be provided
         * `DELETE_REQUESTED`- User requested the deletion of the session before the requested duration expired
 
       type: string


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

This PR clarifies that `createSession` can return `201` with `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED` when the network determines during session creation that the requested QoS cannot be provided.

It also broadens the `NETWORK_TERMINATED` `statusInfo` description to cover that create-time non-fulfilment case without adding a new enum value.

#### Which issue(s) this PR fixes:

Fixes #520

#### Special notes for reviewers:

Doc-only clarification. No new `statusInfo` enum value is introduced, so the change remains suitable for `quality-on-demand` v1.2.0.

The existing `createSession` Gherkin test definition already allows this outcome at the generic success-scenario level: it expects a `201` response that complies with `SessionInfo`, and `statusInfo` is present only when `qosStatus` is `UNAVAILABLE`. There is no dedicated scenario that forces the create-time `UNAVAILABLE` branch.

#### Changelog input

```
release-note
Clarify that createSession may return qosStatus UNAVAILABLE with statusInfo NETWORK_TERMINATED when the network cannot provide the requested QoS during session creation.
```

#### Additional documentation

This section can be blank.

```
docs
```