### PR TITLE
Align quality-on-demand API and tests with Commonalities 0.8.0 (r4.3)

### DIFF
--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -200,7 +200,7 @@ paths:
                 content:
                   application/cloudevents+json:
                     schema:
-                      $ref: "#/components/schemas/CloudEvent"
+                      $ref: "#/components/schemas/QosNotificationEvent"
                     examples:
                       QOS_STATUS_CHANGED_EXAMPLE:
                         $ref: "#/components/examples/QOS_STATUS_CHANGED_EXAMPLE"
@@ -482,10 +482,7 @@ components:
     openId:
       $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
     notificationsBearerAuth:
-      description: Bearer authentication for notifications
-      type: http
-      scheme: bearer
-      bearerFormat: "{$request.body#sinkCredential.credentialType}"
+      $ref: "../common/CAMARA_event_common.yaml#/components/securitySchemes/notificationsBearerAuth"
 
   schemas:
     SessionId:
@@ -520,7 +517,7 @@ components:
         sinkCredential:
           description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
           allOf:
-            - $ref: "#/components/schemas/SinkCredential"
+            - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
       required:
         - applicationServer
         - qosProfile
@@ -644,110 +641,6 @@ components:
           - 5060
           - 5070
 
-    SinkCredential:
-      type: object
-      properties:
-        credentialType:
-          type: string
-          enum:
-            - PLAIN
-            - ACCESSTOKEN
-            - REFRESHTOKEN
-          description: |
-            The type of the credential.
-            Note: Type of the credential - MUST be set to ACCESSTOKEN for now
-      discriminator:
-        propertyName: credentialType
-        mapping:
-          PLAIN: "#/components/schemas/PlainCredential"
-          ACCESSTOKEN: "#/components/schemas/AccessTokenCredential"
-          REFRESHTOKEN: "#/components/schemas/RefreshTokenCredential"
-      required:
-        - credentialType
-
-    PlainCredential:
-      type: object
-      description: A plain credential as a combination of an identifier and a secret. MUST not be used in this API version.
-      allOf:
-        - $ref: "#/components/schemas/SinkCredential"
-        - type: object
-          required:
-            - identifier
-            - secret
-          properties:
-            identifier:
-              description: The identifier might be an account or username.
-              type: string
-            secret:
-              description: The secret might be a password or passphrase.
-              type: string
-
-    AccessTokenCredential:
-      type: object
-      description: An access token credential.
-      allOf:
-        - $ref: "#/components/schemas/SinkCredential"
-        - type: object
-          properties:
-            accessToken:
-              description: REQUIRED. An access token is a previously acquired token granting access to the target resource.
-              type: string
-            accessTokenExpiresUtc:
-              type: string
-              format: date-time
-              description: |
-                REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired. Token expiration should occur
-                after the termination of the requested session, allowing the client to be notified of any changes during the
-                sessions's existence. If the token expires while the session is still active, the client will stop receiving notifications.
-                If the access token is a JWT and registered "exp" (Expiration Time) claim is present, the two expiry times should match.
-                It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-              example: "2023-07-03T12:27:08.312Z"
-            accessTokenType:
-              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)). For the current version of the API the type MUST be set to `Bearer`.
-              type: string
-              enum:
-                - bearer
-          required:
-            - accessToken
-            - accessTokenExpiresUtc
-            - accessTokenType
-
-    RefreshTokenCredential:
-      type: object
-      description: An access token credential with a refresh token. MUST not be used in this API version.
-      allOf:
-        - $ref: "#/components/schemas/SinkCredential"
-        - type: object
-          properties:
-            accessToken:
-              description: REQUIRED. An access token is a previously acquired token granting access to the target resource.
-              type: string
-            accessTokenExpiresUtc:
-              type: string
-              format: date-time
-              description: |
-                REQUIRED. An absolute UTC instant at which the token shall be considered expired.
-                If the access token is a JWT and registered "exp" (Expiration Time) claim is present, the two expiry times should match.
-                It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-            accessTokenType:
-              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
-              type: string
-              enum:
-                - bearer
-            refreshToken:
-              description: REQUIRED. An refresh token credential used to acquire access tokens.
-              type: string
-            refreshTokenEndpoint:
-              type: string
-              format: uri
-              description: REQUIRED. A URL at which the refresh token can be traded for an access token.
-      required:
-        - accessToken
-        - accessTokenExpiresUtc
-        - accessTokenType
-        - refreshToken
-        - refreshTokenEndpoint
-
     ExtendSessionDuration:
       description: Attributes required to extend the duration of an active session
       type: object
@@ -778,60 +671,38 @@ components:
       maxLength: 256
       pattern: "^[a-zA-Z0-9_.-]+$"
 
-    CloudEvent:
-      description: Event compliant with the CloudEvents specification
-      type: object
-      required:
-        - id
-        - source
-        - specversion
-        - type
-        - time
-      properties:
-        id:
-          description: Identifier of this event, that must be unique in the source context.
-          type: string
-        source:
-          description: Identifies the context in which an event happened in the specific provider implementation.
-          type: string
-          format: uri-reference
-        type:
-          description: The type of the event.
-          type: string
-          enum:
-            - "org.camaraproject.quality-on-demand.v1.qos-status-changed"
-        specversion:
-          description: Version of the specification to which this event conforms (must be 1.0 if it conforms to Cloudevents 1.0.2 version)
-          type: string
-          enum:
-            - '1.0'
-        datacontenttype:
-          description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
-          type: string
-          enum:
-            - 'application/json'
-        data:
-          description: Event notification details payload, which depends on the event type
-          type: object
-        time:
-          description: |
-            Timestamp of when the occurrence happened. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-          type: string
-          format: date-time
+    QosEventType:
+      type: string
+      description: |
+        Event type for QoD notifications, using the CAMARA reverse-DNS notation
+        `org.camaraproject.<api-name>.<event-version>.<event-name>`.
+      enum:
+        - org.camaraproject.quality-on-demand.v1.qos-status-changed
+
+    QosNotificationEvent:
+      description: |
+        QoD notification event group. Extends the common CloudEvent envelope and
+        constrains `type` to the event types defined by this API.
+      allOf:
+        - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/CloudEvent"
+        - type: object
+          properties:
+            type:
+              $ref: "#/components/schemas/QosEventType"
       discriminator:
-        propertyName: 'type'
+        propertyName: type
         mapping:
           org.camaraproject.quality-on-demand.v1.qos-status-changed: "#/components/schemas/EventQosStatusChanged"
 
     EventQosStatusChanged:
       description: Event to notify a QoS status change
       allOf:
-        - $ref: "#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/QosNotificationEvent"
         - type: object
           properties:
             data:
               type: object
-              description: Event details depending on the event type
+              description: Event details for a QoS status change
               required:
                 - sessionId
                 - qosStatus
@@ -1261,6 +1132,7 @@ components:
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
+                      - PRIVATE_KEY_JWT_NOT_CONFIGURED
                       - QUALITY_ON_DEMAND.QOS_PROFILE_NOT_APPLICABLE
           examples:
             GENERIC_422_SERVICE_NOT_APPLICABLE:
@@ -1287,6 +1159,12 @@ components:
                 status: 422
                 code: UNNECESSARY_IDENTIFIER
                 message: The device is already identified by the access token.
+            GENERIC_422_PRIVATE_KEY_JWT_NOT_CONFIGURED:
+              description: Private key JWT sink credential type is used but no configuration was pre-shared
+              value:
+                status: 422
+                code: PRIVATE_KEY_JWT_NOT_CONFIGURED
+                message: No JWK Set configured for PRIVATE_KEY_JWT authentication.
             QUALITY_ON_DEMAND_422_QOS_PROFILE_NOT_APPLICABLE:
               description: The requested QoS Profile exists but cannot be used to create a session.
               value:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -66,21 +66,22 @@ info:
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
     <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
+    <!-- CAMARA:MANDATORY:identifying-device-from-access-token:BEGIN -->
+
     # Identifying the device from the access token
 
     This API requires the API consumer to identify a device as the subject of the API as follows:
     - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
-
     - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.
 
     This approach simplifies API usage for API consumers using a three-legged access token to invoke the API by relying on the information that is associated with the access token and was identified during the authentication process.
 
     ## Error handling:
+
     - If the subject cannot be identified from the access token and the optional `device` object is not included in the request, then the server will return an error with the `422 MISSING_IDENTIFIER` error code.
 
     - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
-
-    - If the requested `qosProfile` exists but is currently not available for creating a session (e.g., its status is INACTIVE or DEPRECATED), then the server will return an error with the `422 QUALITY_ON_DEMAND.QOS_PROFILE_NOT_APPLICABLE` error code.
+    <!-- CAMARA:MANDATORY:identifying-device-from-access-token:END -->
 
     # Multi-SIM scenario handling
 
@@ -158,6 +159,7 @@ paths:
         - The access token may be either 2-legged or 3-legged. See "Identifying the device from the access token" for further information
           - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
           - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.
+        - If the requested `qosProfile` exists but is currently not available for creating a session (e.g., its status is INACTIVE or DEPRECATED), then the server will return an error with the `422 QUALITY_ON_DEMAND.QOS_PROFILE_NOT_APPLICABLE` error code.
 
       operationId: createSession
       security:
@@ -215,7 +217,7 @@ paths:
                 "401":
                   $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
                 "403":
-                  $ref: "#/components/responses/Generic403"
+                  $ref: "#/components/responses/PermissionDenied403"
                 "410":
                   $ref: "../common/CAMARA_common.yaml#/components/responses/Generic410"
               security:
@@ -245,7 +247,7 @@ paths:
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/PermissionDenied403"
         "404":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
         "409":
@@ -300,9 +302,9 @@ paths:
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/PermissionDenied403"
         "404":
-          $ref: "#/components/responses/Generic404"
+          $ref: "#/components/responses/NotFound404"
         "429":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
 
@@ -346,9 +348,9 @@ paths:
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/PermissionDenied403"
         "404":
-          $ref: "#/components/responses/Generic404"
+          $ref: "#/components/responses/NotFound404"
         "429":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
 
@@ -409,9 +411,9 @@ paths:
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/PermissionDenied403"
         "404":
-          $ref: "#/components/responses/Generic404"
+          $ref: "#/components/responses/NotFound404"
         "409":
           $ref: "#/components/responses/SessionStatusConflict409"
         "429":
@@ -466,7 +468,7 @@ paths:
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/PermissionDenied403"
         "404":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
         "422":
@@ -598,13 +600,6 @@ components:
           required:
             - duration
 
-    Port:
-      description: TCP or UDP port number
-      type: integer
-      format: int32
-      minimum: 0
-      maximum: 65535
-
     PortsSpec:
       description: Specification of several TCP or UDP ports
       type: object
@@ -623,16 +618,16 @@ components:
               - to
             properties:
               from:
-                $ref: "#/components/schemas/Port"
+                $ref: "../common/CAMARA_common.yaml#/components/schemas/Port"
               to:
-                $ref: "#/components/schemas/Port"
+                $ref: "../common/CAMARA_common.yaml#/components/schemas/Port"
         ports:
           description: Array of TCP or UDP ports
           type: array
           minItems: 1
           maxItems: 65536
           items:
-            $ref: "#/components/schemas/Port"
+            $ref: "../common/CAMARA_common.yaml#/components/schemas/Port"
       example:
         ranges:
           - from: 5010
@@ -1010,7 +1005,7 @@ components:
                 code: INVALID_ARGUMENT
                 message: Client specified an invalid argument, request body or query param.
 
-    Generic403:
+    PermissionDenied403:
       description: Forbidden
       headers:
         x-correlator:
@@ -1036,7 +1031,7 @@ components:
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
 
-    Generic404:
+    NotFound404:
       description: Not found
       headers:
         x-correlator:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -55,6 +55,8 @@ info:
 
     ![QoD Management API](https://raw.githubusercontent.com/camaraproject/QualityOnDemand/main/documentation/API_documentation/resources/QoD_details.PNG)
 
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
+
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
@@ -62,6 +64,7 @@ info:
     The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
     # Identifying the device from the access token
 
@@ -88,19 +91,29 @@ info:
     - Identifying the intended device from a unique identifier for that device, such as its source IP address and port
     - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device, and use the secondary phone number to identify the intended device if available
 
+    <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
+
     # Additional CAMARA error responses
 
-    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
 
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+    <!-- CAMARA:MANDATORY:additional-error-responses:END -->
+
+    <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+
+    # Request body strictness
+
+    This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.
+    <!-- CAMARA:MANDATORY:request-body-strictness:END -->
 
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.6
+  x-camara-commonalities: 0.8.0
 
 externalDocs:
   description: Product documentation at CAMARA
@@ -151,7 +164,7 @@ paths:
         - openId:
             - quality-on-demand:sessions:create
       parameters:
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       requestBody:
         description: Parameters to create a new session
         required: true
@@ -181,7 +194,7 @@ paths:
                 Currently only QOS_STATUS_CHANGED event is defined.
               operationId: postNotification
               parameters:
-                - $ref: "#/components/parameters/x-correlator"
+                - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
               requestBody:
                 required: true
                 content:
@@ -196,15 +209,15 @@ paths:
                   description: Successful notification
                   headers:
                     x-correlator:
-                      $ref: '#/components/headers/x-correlator'
+                      $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
                 "400":
-                  $ref: "#/components/responses/Generic400"
+                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
                 "401":
-                  $ref: "#/components/responses/Generic401"
+                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
                 "403":
                   $ref: "#/components/responses/Generic403"
                 "410":
-                  $ref: "#/components/responses/Generic410"
+                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic410"
               security:
                 - {}
                 - notificationsBearerAuth: []
@@ -213,7 +226,7 @@ paths:
           description: Session created
           headers:
             x-correlator:
-              $ref: '#/components/headers/x-correlator'
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -230,17 +243,17 @@ paths:
         "400":
           $ref: "#/components/responses/CreateSessionBadRequest400"
         "401":
-          $ref: "#/components/responses/Generic401"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "#/components/responses/GenericDevice404"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
         "409":
           $ref: "#/components/responses/SessionInConflict409"
         "422":
           $ref: "#/components/responses/CreateSessionUnprocessableEntity422"
         "429":
-          $ref: "#/components/responses/Generic429"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
 
   /sessions/{sessionId}:
     get:
@@ -266,13 +279,13 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/SessionId"
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       responses:
         "200":
           description: Contains information about active session
           headers:
             x-correlator:
-              $ref: '#/components/headers/x-correlator'
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -285,13 +298,13 @@ paths:
         "400":
           $ref: "#/components/responses/GetSessionBadRequest400"
         "401":
-          $ref: "#/components/responses/Generic401"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/Generic404"
         "429":
-          $ref: "#/components/responses/Generic429"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
 
     delete:
       tags:
@@ -321,23 +334,23 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/SessionId"
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       responses:
         "204":
           description: Session deleted
           headers:
             x-correlator:
-              $ref: '#/components/headers/x-correlator'
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
         "400":
           $ref: "#/components/responses/DeleteSessionBadRequest400"
         "401":
-          $ref: "#/components/responses/Generic401"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/Generic404"
         "429":
-          $ref: "#/components/responses/Generic429"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
 
   /sessions/{sessionId}/extend:
     post:
@@ -368,7 +381,7 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/SessionId"
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       requestBody:
         description: Parameters to extend the duration of an active session
         content:
@@ -381,7 +394,7 @@ paths:
           description: Contains information about active session
           headers:
             x-correlator:
-              $ref: '#/components/headers/x-correlator'
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -394,7 +407,7 @@ paths:
         "400":
           $ref: "#/components/responses/GenericExtendSessionDuration400"
         "401":
-          $ref: "#/components/responses/Generic401"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
@@ -402,7 +415,7 @@ paths:
         "409":
           $ref: "#/components/responses/SessionStatusConflict409"
         "429":
-          $ref: "#/components/responses/Generic429"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
 
   /retrieve-sessions:
     post:
@@ -423,7 +436,7 @@ paths:
 
       operationId: retrieveSessionsByDevice
       parameters:
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       requestBody:
         description: Parameters to get QoS session information by device
         content:
@@ -436,7 +449,7 @@ paths:
           description: Returns the QoS sessions information for a given device. A device may have multiple sessions, thus the response is an array. An empty array is returned if no sessions are found.
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -449,17 +462,17 @@ paths:
                 RETRIEVE_SESSIONS_NO_ITEMS:
                   $ref: "#/components/examples/RETRIEVE_SESSIONS_EMPTY_EXAMPLE"
         "400":
-          $ref: "#/components/responses/Generic400"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
-          $ref: "#/components/responses/Generic401"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "#/components/responses/GenericDevice404"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
         "422":
-          $ref: "#/components/responses/Generic422"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic422"
         "429":
-          $ref: "#/components/responses/Generic429"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
       security:
         - openId:
             - "quality-on-demand:sessions:retrieve-by-device"
@@ -467,39 +480,19 @@ paths:
 components:
   securitySchemes:
     openId:
-      type: openIdConnect
-      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+      $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
     notificationsBearerAuth:
       description: Bearer authentication for notifications
       type: http
       scheme: bearer
       bearerFormat: "{$request.body#sinkCredential.credentialType}"
 
-  parameters:
-    x-correlator:
-      name: x-correlator
-      in: header
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
-
-  headers:
-    x-correlator:
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
-
   schemas:
-    XCorrelator:
-      description: Value for the x-correlator
-      type: string
-      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
-      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
-
     SessionId:
       description: Session ID in UUID format
       type: string
       format: uuid
+      maxLength: 36
 
     BaseSessionInfo:
       description: Common attributes of a QoS session
@@ -520,6 +513,7 @@ components:
         sink:
           type: string
           format: uri
+          maxLength: 2048
           pattern: ^https:\/\/.+$
           description: The address to which events about all status changes of the session (e.g. session termination) shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
@@ -542,7 +536,7 @@ components:
             device:
               description: Disambiguates the device to which the session applies when multiple device identifiers were provided
               allOf:
-                - $ref: "#/components/schemas/DeviceResponse"
+                - $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
                 - example: {"phoneNumber": "+123456789"}
         - $ref: "#/components/schemas/BaseSessionInfo"
         - type: object
@@ -558,11 +552,13 @@ components:
               type: integer
               format: int32
               minimum: 1
+              maximum: 2147483647
               example: 3600
             startedAt:
               description: Date and time when the QoS status became "AVAILABLE". Not to be returned when `qosStatus` is "REQUESTED". It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
               type: string
               format: date-time
+              maxLength: 64
               example: "2024-06-01T12:00:00Z"
             expiresAt:
               description: |
@@ -573,6 +569,7 @@ components:
                 When the session is extended, the value is the new expiration time of the session.
               type: string
               format: date-time
+              maxLength: 64
               example: "2024-06-01T13:00:00Z"
             qosStatus:
               $ref: "#/components/schemas/QosStatus"
@@ -589,7 +586,7 @@ components:
         - type: object
           properties:
             device:
-              $ref: "#/components/schemas/Device"
+              $ref: "../common/CAMARA_common.yaml#/components/schemas/Device"
         - $ref: "#/components/schemas/BaseSessionInfo"
         - type: object
           properties:
@@ -599,6 +596,7 @@ components:
               type: integer
               format: int32
               minimum: 1
+              maximum: 2147483647
               example: 3600
           required:
             - duration
@@ -606,6 +604,7 @@ components:
     Port:
       description: TCP or UDP port number
       type: integer
+      format: int32
       minimum: 0
       maximum: 65535
 
@@ -618,7 +617,9 @@ components:
           description: Range of TCP or UDP ports
           type: array
           minItems: 1
+          maxItems: 65536
           items:
+            description: A single range of TCP or UDP ports, specified by its first and last port (inclusive)
             type: object
             required:
               - from
@@ -632,6 +633,7 @@ components:
           description: Array of TCP or UDP ports
           type: array
           minItems: 1
+          maxItems: 65536
           items:
             $ref: "#/components/schemas/Port"
       example:
@@ -756,6 +758,7 @@ components:
           type: integer
           format: int32
           minimum: 1
+          maximum: 2147483647
           example: 1800
       required:
         - requestedAdditionalDuration
@@ -855,41 +858,6 @@ components:
         - NETWORK_TERMINATED
         - DELETE_REQUESTED
 
-    Device:
-      description: |
-        End-user equipment able to connect to a network. Examples of devices include smartphones or IoT sensors/actuators.
-
-        The API consumer can choose to provide the below specified device identifiers:
-
-        * `ipv4Address`
-        * `ipv6Address`
-        * `phoneNumber`
-        * `networkAccessIdentifier`
-
-        NOTE1: the network operator might support only a subset of these options. The API consumer can provide multiple identifiers to be compatible across different network operators. In this case the identifiers MUST belong to the same device.
-        NOTE2: as for this Commonalities release, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
-      type: object
-      properties:
-        phoneNumber:
-          $ref: "#/components/schemas/PhoneNumber"
-        networkAccessIdentifier:
-          $ref: "#/components/schemas/NetworkAccessIdentifier"
-        ipv4Address:
-          $ref: "#/components/schemas/DeviceIpv4Addr"
-        ipv6Address:
-          $ref: "#/components/schemas/DeviceIpv6Address"
-      minProperties: 1
-
-    DeviceResponse:
-      description: |
-        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
-
-        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
-
-      allOf:
-        - $ref: "#/components/schemas/Device"
-        - maxProperties: 1
-
     ApplicationServer:
       description: |
         A server hosting backend applications to deliver some business logic to clients.
@@ -943,43 +911,6 @@ components:
           - $ref: "#/components/schemas/SingleIpv4Addr"
           - $ref: "#/components/schemas/SingleIpv6Addr"
 
-    NetworkAccessIdentifier:
-      description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
-      type: string
-      example: "123456789@domain.com"
-
-    PhoneNumber:
-      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
-      type: string
-      pattern: '^\+[1-9][0-9]{4,14}$'
-      example: "+123456789"
-
-    DeviceIpv4Addr:
-      type: object
-      description: |
-        The device should be identified by either the public (observed) IP address and port as seen by the application server, or the private (local) and any public (observed) IP addresses in use by the device (this information can be obtained by various means, for example from some DNS servers).
-
-        If the allocated and observed IP addresses are the same (i.e. NAT is not in use) then  the same address should be specified for both publicAddress and privateAddress.
-
-        If NAT64 is in use, the device should be identified by its publicAddress and publicPort, or separately by its allocated IPv6 address (field ipv6Address of the Device object)
-
-        In all cases, publicAddress must be specified, along with at least one of either privateAddress or publicPort, dependent upon which is known. In general, mobile devices cannot be identified by their public IPv4 address alone.
-      properties:
-        publicAddress:
-          $ref: "#/components/schemas/SingleIpv4Addr"
-        privateAddress:
-          $ref: "#/components/schemas/SingleIpv4Addr"
-        publicPort:
-          $ref: "#/components/schemas/Port"
-      anyOf:
-        - required: [publicAddress, privateAddress]
-        - required: [publicAddress, publicPort]
-      example:
-        {
-          "publicAddress": "203.0.113.0",
-          "publicPort": 59765
-        }
-
     SingleIpv4Addr:
       description: A single IPv4 address with no subnet mask
       type: string
@@ -994,18 +925,10 @@ components:
       format: ipv6
       example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
 
-    DeviceIpv6Address:
-      description: |
-        The device should be identified by the observed IPv6 address, or by any single IPv6 address from within the subnet allocated to the device (e.g. adding ::0 to the /64 prefix).
-
-        The session shall apply to all IP flows between the device subnet and the specified application server, unless further restricted by the optional parameters devicePorts or applicationServerPorts.
-      type: string
-      format: ipv6
-      example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
-
     ApplicationServerIpv4Address:
       type: string
       maxLength: 18
+      pattern: '^([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])(\.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])){3}(\/(3[0-2]|[12]?[0-9]))?$'
       example: "198.51.100.0/24"
       description: |
         IPv4 address may be specified in form <address/mask> as:
@@ -1016,6 +939,7 @@ components:
     ApplicationServerIpv6Address:
       type: string
       maxLength: 49
+      pattern: '^[0-9a-fA-F:.]+(\/(12[0-8]|1[0-1][0-9]|[1-9]?[0-9]))?$'
       example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
       description: |
         IPv6 address may be specified in form <address/mask> as:
@@ -1048,30 +972,12 @@ components:
         - AVAILABLE
         - UNAVAILABLE
 
-    ErrorInfo:
-      description: Common schema for errors
-      type: object
-      properties:
-        status:
-          type: integer
-          description: HTTP response status code
-        code:
-          type: string
-          description: A human-readable code to describe the error
-        message:
-          type: string
-          description: A human-readable description of what the event represents
-      required:
-        - status
-        - code
-        - message
-
     RetrieveSessionsInput:
       description: Parameters to get QoS session information by device
       type: object
       properties:
         device:
-          $ref: "#/components/schemas/Device"
+          $ref: "../common/CAMARA_common.yaml#/components/schemas/Device"
 
     RetrieveSessionsOutput:
       description: QoS session information for a given device
@@ -1079,18 +985,19 @@ components:
       items:
         $ref: "#/components/schemas/SessionInfo"
       minItems: 0
+      maxItems: 100
 
   responses:
     CreateSessionBadRequest400:
       description: Bad Request when creating a session
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -1144,12 +1051,12 @@ components:
       description: Bad Request
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -1184,12 +1091,12 @@ components:
       description: Bad Request when retrieving a session
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -1210,12 +1117,12 @@ components:
       description: Bad Request when deleting a session
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -1231,76 +1138,17 @@ components:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: Client specified an invalid argument, request body or query param.
-
-    Generic400:
-      description: Bad Request
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 400
-                  code:
-                    enum:
-                      - INVALID_ARGUMENT
-                      - OUT_OF_RANGE
-          examples:
-            GENERIC_400_INVALID_ARGUMENT:
-              description: Invalid Argument. Generic Syntax Exception
-              value:
-                status: 400
-                code: INVALID_ARGUMENT
-                message: Client specified an invalid argument, request body or query param.
-            GENERIC_400_OUT_OF_RANGE:
-              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
-              value:
-                status: 400
-                code: OUT_OF_RANGE
-                message: Client specified an invalid range.
-
-    Generic401:
-      description: Unauthorized
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 401
-                  code:
-                    enum:
-                      - UNAUTHENTICATED
-          examples:
-            GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated and a new authentication is required
-              value:
-                status: 401
-                code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
 
     Generic403:
       description: Forbidden
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -1321,12 +1169,12 @@ components:
       description: Not found
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -1342,50 +1190,17 @@ components:
                 status: 404
                 code: NOT_FOUND
                 message: The specified resource is not found.
-
-    GenericDevice404:
-      description: Not found
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 404
-                  code:
-                    enum:
-                      - NOT_FOUND
-                      - IDENTIFIER_NOT_FOUND
-          examples:
-            GENERIC_404_NOT_FOUND:
-              description: Resource is not found
-              value:
-                status: 404
-                code: NOT_FOUND
-                message: The specified resource is not found.
-            GENERIC_404_DEVICE_NOT_FOUND:
-              description: Device identifier not found
-              value:
-                status: 404
-                code: IDENTIFIER_NOT_FOUND
-                message: Device identifier not found.
 
     SessionInConflict409:
       description: Conflict
       headers:
         x-correlator:
-          $ref: '#/components/headers/x-correlator'
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -1403,12 +1218,12 @@ components:
       description: Conflict
       headers:
         x-correlator:
-          $ref: '#/components/headers/x-correlator'
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -1425,88 +1240,16 @@ components:
                 code: QUALITY_ON_DEMAND.SESSION_EXTENSION_NOT_ALLOWED
                 message: Extending the session duration is not allowed in the current state ({qosStatus}). The session must be in the AVAILABLE state.
 
-    Generic410:
-      description: Gone
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 410
-                  code:
-                    enum:
-                      - GONE
-          examples:
-            GENERIC_410_GONE:
-              description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
-              value:
-                status: 410
-                code: GONE
-                message: Access to the target resource is no longer available.
-
-    Generic422:
-      description: Unprocessable Content
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 422
-                  code:
-                    enum:
-                      - SERVICE_NOT_APPLICABLE
-                      - MISSING_IDENTIFIER
-                      - UNSUPPORTED_IDENTIFIER
-                      - UNNECESSARY_IDENTIFIER
-          examples:
-            GENERIC_422_SERVICE_NOT_APPLICABLE:
-              description: Service not applicable for the provided identifier
-              value:
-                status: 422
-                code: SERVICE_NOT_APPLICABLE
-                message: The service is not available for the provided identifier.
-            GENERIC_422_MISSING_IDENTIFIER:
-              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the access token
-              value:
-                status: 422
-                code: MISSING_IDENTIFIER
-                message: The device cannot be identified.
-            GENERIC_422_UNSUPPORTED_IDENTIFIER:
-              description: None of the provided identifiers is supported by the implementation
-              value:
-                status: 422
-                code: UNSUPPORTED_IDENTIFIER
-                message: The identifier provided is not supported.
-            GENERIC_422_UNNECESSARY_IDENTIFIER:
-              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
-              value:
-                status: 422
-                code: UNNECESSARY_IDENTIFIER
-                message: The device is already identified by the access token.
     CreateSessionUnprocessableEntity422:
       description: Unprocessable Content
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -1550,39 +1293,6 @@ components:
                 status: 422
                 code: QUALITY_ON_DEMAND.QOS_PROFILE_NOT_APPLICABLE
                 message: The requested QoS Profile is currently not available for session creation.
-
-    Generic429:
-      description: Too Many Requests
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 429
-                  code:
-                    enum:
-                      - QUOTA_EXCEEDED
-                      - TOO_MANY_REQUESTS
-          examples:
-            GENERIC_429_QUOTA_EXCEEDED:
-              description: Request is rejected due to exceeding a business quota limit
-              value:
-                status: 429
-                code: QUOTA_EXCEEDED
-                message: Out of resource quota.
-            GENERIC_429_TOO_MANY_REQUESTS:
-              description: Access to the API has been temporarily blocked due to rate or spike arrest limits being reached
-              value:
-                status: 429
-                code: TOO_MANY_REQUESTS
-                message: Rate limit reached.
 
   examples:
     EXAMPLE_1_CREATION_BODY_3-LEGGED_ACCESS_TOKEN_IPv4_SUBNET:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -38,7 +38,7 @@ info:
 
      * **Notification URL and token**:
     The API consumer may provide a callback URL (`sink`) on which notifications about all status change events (eg. session termination) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message.
-    If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint. In the current version, `sinkCredential.credentialType` MUST be set to `ACCESSTOKEN` if provided.
+    If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint. If provided, `sinkCredential.credentialType` MUST be set to `ACCESSTOKEN` or `PRIVATE_KEY_JWT`.
 
     # API functionality
 

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -117,7 +117,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
     Examples:
       | device_identifier                | oas_spec_schema                             |
       | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
-      | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+      | $.device.ipv4Address             | /components/schemas/DeviceIpv4Address       |
       | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
       | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
@@ -302,6 +302,14 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  @quality_on_demand_createSession_400.10_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "#/components/schemas/XCorrelator"
+    When the request "createSession" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
   # Generic 401 errors
 
   @quality_on_demand_createSession_401.1_no_authorization_header
@@ -345,7 +353,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
 
   @quality_on_demand_createSession_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope quality-on-demand:sessions:create
+    Given the header "Authorization" is set to an access token that does not include scope "quality-on-demand:sessions:create"
     When the request "createSession" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -380,4 +388,18 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 422
     And the response property "$.code" is "QUALITY_ON_DEMAND.QOS_PROFILE_NOT_APPLICABLE"
+    And the response property "$.message" contains a user friendly text
+
+  # Errors 429
+
+  @quality_on_demand_createSession_429.1_too_many_requests
+  # To test this scenario the environment has to be configured to reject requests reaching the threshold limit set.
+  Scenario: Request is rejected due to threshold policy
+    Given a valid request for "createSession"
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the request "createSession" is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/quality-on-demand-createSession.feature
+++ b/code/Test_definitions/quality-on-demand-createSession.feature
@@ -251,15 +251,17 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
       | $.applicationServerPorts.ports[*]    |
 
   # PLAIN and REFRESHTOKEN are considered in the schema so INVALID_ARGUMENT is not expected
-  @quality_on_demand_createSession_400.6_invalid_sink_credential
-  Scenario Outline: Invalid credential
+  # PLAIN and REFRESHTOKEN are no longer valid "credentialType" values in the common SinkCredential
+  # schema, so a request carrying them fails schema validation with INVALID_ARGUMENT.
+  @quality_on_demand_createSession_400.6_unsupported_sink_credential_type
+  Scenario Outline: Unsupported sinkCredential.credentialType value
     Given the request body property  "$.sinkCredential.credentialType" is set to "<unsupported_credential_type>"
     When the request "createSession" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
-    And the response property "$.code" is "INVALID_CREDENTIAL"
+    And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
     Examples:
@@ -388,6 +390,19 @@ Feature: CAMARA Quality On Demand API, vwip - Operation createSession
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 422
     And the response property "$.code" is "QUALITY_ON_DEMAND.QOS_PROFILE_NOT_APPLICABLE"
+    And the response property "$.message" contains a user friendly text
+
+  @quality_on_demand_createSession_422.2_private_key_jwt_not_configured
+  Scenario: PRIVATE_KEY_JWT sink credential used but not pre-configured
+    Given a valid testing device supported by the service, identified by the token or provided in the request body
+    And the request body property "$.sinkCredential.credentialType" is set to "PRIVATE_KEY_JWT"
+    And no PRIVATE_KEY_JWT configuration has been pre-shared for the notification endpoint
+    When the request "createSession" is sent
+    Then the response status code is 422
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 422
+    And the response property "$.code" is "PRIVATE_KEY_JWT_NOT_CONFIGURED"
     And the response property "$.message" contains a user friendly text
 
   # Errors 429

--- a/code/Test_definitions/quality-on-demand-deleteSession.feature
+++ b/code/Test_definitions/quality-on-demand-deleteSession.feature
@@ -61,6 +61,14 @@ Feature: CAMARA Quality On Demand API, vwip - Operation deleteSession
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  @quality_on_demand_deleteSession_400.2_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "#/components/schemas/XCorrelator"
+    When the request "deleteSession" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
   # Generic 401 errors
 
   @quality_on_demand_deleteSession_401.1_no_authorization_header
@@ -101,7 +109,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation deleteSession
 
   @quality_on_demand_deleteSession_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope quality-on-demand:sessions:delete
+    Given the header "Authorization" is set to an access token that does not include scope "quality-on-demand:sessions:delete"
     When the request "deleteSession" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -133,4 +141,18 @@ Feature: CAMARA Quality On Demand API, vwip - Operation deleteSession
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+
+  # Errors 429
+
+  @quality_on_demand_deleteSession_429.1_too_many_requests
+  # To test this scenario the environment has to be configured to reject requests reaching the threshold limit set.
+  Scenario: Request is rejected due to threshold policy
+    Given a valid request for "deleteSession"
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the request "deleteSession" is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/quality-on-demand-extendQosSessionDuration.feature
+++ b/code/Test_definitions/quality-on-demand-extendQosSessionDuration.feature
@@ -103,6 +103,14 @@ Feature: CAMARA Quality On Demand API, vwip - Operation extendQosSessionDuration
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  @quality_on_demand_extendQosSessionDuration_400.5_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "#/components/schemas/XCorrelator"
+    When the request "extendQosSessionDuration" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
   # Generic 401 errors
 
   @quality_on_demand_extendQosSessionDuration_401.1_no_authorization_header
@@ -146,7 +154,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation extendQosSessionDuration
 
   @quality_on_demand_extendQosSessionDuration_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope quality-on-demand:sessions:update
+    Given the header "Authorization" is set to an access token that does not include scope "quality-on-demand:sessions:update"
     When the request "extendQosSessionDuration" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -194,4 +202,18 @@ Feature: CAMARA Quality On Demand API, vwip - Operation extendQosSessionDuration
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 409
     And the response property "$.code" is "QUALITY_ON_DEMAND.SESSION_EXTENSION_NOT_ALLOWED"
+    And the response property "$.message" contains a user friendly text
+
+  # Errors 429
+
+  @quality_on_demand_extendQosSessionDuration_429.1_too_many_requests
+  # To test this scenario the environment has to be configured to reject requests reaching the threshold limit set.
+  Scenario: Request is rejected due to threshold policy
+    Given a valid request for "extendQosSessionDuration"
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the request "extendQosSessionDuration" is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/quality-on-demand-getSession.feature
+++ b/code/Test_definitions/quality-on-demand-getSession.feature
@@ -66,6 +66,14 @@ Feature: CAMARA Quality On Demand API, vwip - Operation getSession
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  @quality_on_demand_getSession_400.2_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "#/components/schemas/XCorrelator"
+    When the request "getSession" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
   # Generic 401 errors
 
   @quality_on_demand_getSession_401.1_no_authorization_header
@@ -106,7 +114,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation getSession
 
   @quality_on_demand_getSession_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope quality-on-demand:sessions:read
+    Given the header "Authorization" is set to an access token that does not include scope "quality-on-demand:sessions:read"
     When the request "getSession" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -138,4 +146,18 @@ Feature: CAMARA Quality On Demand API, vwip - Operation getSession
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+
+  # Errors 429
+
+  @quality_on_demand_getSession_429.1_too_many_requests
+  # To test this scenario the environment has to be configured to reject requests reaching the threshold limit set.
+  Scenario: Request is rejected due to threshold policy
+    Given a valid request for "getSession"
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the request "getSession" is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
+++ b/code/Test_definitions/quality-on-demand-retrieveSessionsByDevice.feature
@@ -80,7 +80,7 @@ Feature: CAMARA Quality On Demand API, vwip - Operation retrieveSessionsByDevice
     Examples:
       | device_identifier                | oas_spec_schema                             |
       | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
-      | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+      | $.device.ipv4Address             | /components/schemas/DeviceIpv4Address       |
       | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
       | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
@@ -161,6 +161,14 @@ Feature: CAMARA Quality On Demand API, vwip - Operation retrieveSessionsByDevice
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  @quality_on_demand_retrieveSessionsByDevice_400.3_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "#/components/schemas/XCorrelator"
+    When the request "retrieveSessionsByDevice" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
   # Generic 401 errors
 
   @quality_on_demand_retrieveSessionsByDevice_401.1_no_authorization_header
@@ -204,11 +212,25 @@ Feature: CAMARA Quality On Demand API, vwip - Operation retrieveSessionsByDevice
 
   @quality_on_demand_retrieveSessionsByDevice_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope quality-on-demand:sessions:retrieve-by-device
+    Given the header "Authorization" is set to an access token that does not include scope "quality-on-demand:sessions:retrieve-by-device"
     When the request "retrieveSessionsByDevice" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text
+
+  # Errors 429
+
+  @quality_on_demand_retrieveSessionsByDevice_429.1_too_many_requests
+  # To test this scenario the environment has to be configured to reject requests reaching the threshold limit set.
+  Scenario: Request is rejected due to threshold policy
+    Given a valid request for "retrieveSessionsByDevice"
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the request "retrieveSessionsByDevice" is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Brings the `quality-on-demand` API specification and its test definitions into line with CAMARA Commonalities 0.8.0 (r4.3). The change is backward-compatible with the released `1.1.0`: each tightened constraint makes an already-intended, domain-limited bound machine-readable and rejects no previously-valid request.

Highlights:
- Reuse the synced common components via `$ref` into `code/common/` at each use-site: `openId`, `x-correlator`, `Device` / `DeviceResponse`, `ErrorInfo`, and the generic error responses. API-specific code-subset error responses are kept local.
- Embed the mandatory `info.description` templates (authorization-and-authentication, additional-error-responses, request-body-strictness) and set `x-camara-commonalities: 0.8.0`.
- Add OWASP-aligned constraints (`maxLength` / `maxItems` / `minimum` / `maximum` / `format` / `pattern`) to the remaining local schemas.
- Align the QoS status-change notifications to the CloudEvents model: consume the shared `CloudEvent` and `SinkCredential` from `CAMARA_event_common.yaml`, express the event as a CloudEvent subtype with its own event-type enum and discriminator, and adopt `ACCESSTOKEN` + `PRIVATE_KEY_JWT` (adding `PRIVATE_KEY_JWT_NOT_CONFIGURED` to the create-session `422`).
- Align the five `quality-on-demand-*.feature` test definitions (repoint the renamed device schema, add `invalid_x-correlator` and `429` scenarios, quote scope values).

The event and notification changes (the single semantic change) are isolated in their own commit, separate from the metadata/reuse/constraints/tests, so each part can be reviewed independently.

#### Which issue(s) this PR fixes:

Fixes #571

#### Special notes for reviewers:

- Backward compatibility: every change is backward-compatible with the released `1.1.0`, so each addition is constrained by Commonalities #658. Dropping `PLAIN` / `REFRESHTOKEN` from the `SinkCredential` enum is a non-breaking restatement (both were already documented as disallowed); `PRIVATE_KEY_JWT` is additive.
- `duration` intentionally has no API-level maximum (the limit is the QoS Profile `maxDuration`); `maximum: 2147483647` is the int32 ceiling, added only to satisfy the linter without restricting any valid value.
- `Port` now references the common `Port` schema (`minimum: 1`); the previous local copy allowed `minimum: 0`. Port 0 is not a usable flow port, so this tightening is a Commonalities #658 clarification that rejects no valid request.
- The validator reports `S-211` (potentially unused component) on `EventQosStatusChanged` — the known false-positive for a discriminator subtype, which Spectral does not follow through the discriminator mapping.

#### Changelog input

```
 release-note
Align the quality-on-demand API and test definitions with CAMARA Commonalities 0.8.0 (r4.3): reuse common components via $ref, add request-body strictness and OWASP constraints, and align the CloudEvents notifications including PRIVATE_KEY_JWT sink credentials. Backward-compatible with 1.1.0.
```

#### Additional documentation

This section can be blank.

```
docs

```
