### PR TITLE
Align qos-provisioning.yaml with CAMARA Commonalities r4.3

### DIFF
--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -30,6 +30,7 @@ info:
     - An operation to get the details of a QoS assignment record for a given device.
     - An operation to revoke the assignment of a QoS profile to a given device, identified by the `assignmentId`.
 
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
@@ -37,6 +38,7 @@ info:
     The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
     # Identifying the device from the access token
 
@@ -63,19 +65,27 @@ info:
     - Identifying the intended device from a unique identifier for that device, such as its source IP address and port
     - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device, and use the secondary phone number to identify the intended device if available.
 
+    <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses
 
-    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
 
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+    <!-- CAMARA:MANDATORY:additional-error-responses:END -->
+
+    <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+    # Request body strictness
+
+    This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.
+    <!-- CAMARA:MANDATORY:request-body-strictness:END -->
 
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.6
+  x-camara-commonalities: 0.8.0
 
 externalDocs:
   description: Project documentation at CAMARA
@@ -375,29 +385,18 @@ components:
         $ref: "#/components/schemas/AssignmentId"
 
     x-correlator:
-      name: x-correlator
-      in: header
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
+      $ref: '../common/CAMARA_common.yaml#/components/parameters/x-correlator'
 
   headers:
     x-correlator:
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
+      $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
 
   schemas:
-    XCorrelator:
-      description: Value for the x-correlator
-      type: string
-      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
-      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
-
     AssignmentId:
       description: Identifier of the assignment record for the QoS profile assignment, that was created by the `createQosAssignment` operation
       type: string
       format: uuid
+      maxLength: 36
 
     BaseAssignmentInfo:
       description: Common attributes of the assignment record for a QoS profile assignment
@@ -410,6 +409,7 @@ components:
         sink:
           type: string
           format: uri
+          maxLength: 2048
           pattern: ^https:\/\/.+$
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
@@ -438,6 +438,7 @@ components:
               description: Date and time when the QoS profile assignment became "AVAILABLE". Not to be returned when `status` is "REQUESTED". It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
               type: string
               format: date-time
+              maxLength: 64
               example: "2024-06-01T12:00:00Z"
             status:
               $ref: "#/components/schemas/Status"
@@ -464,115 +465,13 @@ components:
           $ref: "#/components/schemas/Device"
 
     SinkCredential:
-      description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
-      type: object
-      properties:
-        credentialType:
-          type: string
-          enum:
-            - PLAIN
-            - ACCESSTOKEN
-            - REFRESHTOKEN
-          description: |
-            The type of the credential.
-            Note: Type of the credential - MUST be set to ACCESSTOKEN for now.
-      discriminator:
-        propertyName: credentialType
-        mapping:
-          PLAIN: "#/components/schemas/PlainCredential"
-          ACCESSTOKEN: "#/components/schemas/AccessTokenCredential"
-          REFRESHTOKEN: "#/components/schemas/RefreshTokenCredential"
-      required:
-        - credentialType
-
-    PlainCredential:
-      type: object
-      description: A plain credential as a combination of an identifier and a secret. MUST not be used in this API version.
-      allOf:
-        - $ref: "#/components/schemas/SinkCredential"
-        - type: object
-          required:
-            - identifier
-            - secret
-          properties:
-            identifier:
-              description: The identifier might be an account or username.
-              type: string
-            secret:
-              description: The secret might be a password or passphrase.
-              type: string
+      $ref: '../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential'
 
     AccessTokenCredential:
-      type: object
-      description: An access token credential.
-      allOf:
-        - $ref: "#/components/schemas/SinkCredential"
-        - type: object
-          properties:
-            accessToken:
-              description: REQUIRED. An access token is a previously acquired token granting access to the target resource.
-              type: string
-            accessTokenExpiresUtc:
-              type: string
-              format: date-time
-              description: |
-                REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired. Token expiration should occur
-                after the termination of the requested assignment, allowing the client to be notified of any changes during the
-                assignment's existence. If the token expires while the assignment is still active, the client will stop receiving notifications.
-                If the access token is a JWT and registered "exp" (Expiration Time) claim is present, the two expiry times should match.
-                It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-              example: "2023-07-03T12:27:08.312Z"
-            accessTokenType:
-              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
-              type: string
-              enum:
-                - bearer
-          required:
-            - accessToken
-            - accessTokenExpiresUtc
-            - accessTokenType
+      $ref: '../common/CAMARA_event_common.yaml#/components/schemas/AccessTokenCredential'
 
-    RefreshTokenCredential:
-      type: object
-      description: An access token credential with a refresh token. MUST not be used in this API version.
-      allOf:
-        - $ref: "#/components/schemas/SinkCredential"
-        - type: object
-          properties:
-            accessToken:
-              description: REQUIRED. An access token is a previously acquired token granting access to the target resource.
-              type: string
-            accessTokenExpiresUtc:
-              type: string
-              format: date-time
-              description: |
-                REQUIRED. An absolute UTC instant at which the token shall be considered expired.
-                If the access token is a JWT and registered "exp" (Expiration Time) claim is present, the two expiry times should match.
-                It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-            accessTokenType:
-              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
-              type: string
-              enum:
-                - bearer
-            refreshToken:
-              description: REQUIRED. An refresh token credential used to acquire access tokens.
-              type: string
-            refreshTokenEndpoint:
-              type: string
-              format: uri
-              description: REQUIRED. A URL at which the refresh token can be traded for an access token.
-      required:
-        - accessToken
-        - accessTokenExpiresUtc
-        - accessTokenType
-        - refreshToken
-        - refreshTokenEndpoint
-
-    Port:
-      description: TCP or UDP port number
-      type: integer
-      minimum: 0
-      maximum: 65535
+    PrivateKeyJWTCredential:
+      $ref: '../common/CAMARA_event_common.yaml#/components/schemas/PrivateKeyJWTCredential'
 
     QosProfileName:
       description: |
@@ -589,46 +488,20 @@ components:
       maxLength: 256
       pattern: "^[a-zA-Z0-9_.-]+$"
 
+    ApiEventType:
+      description: The type identifier for QoS provisioning status-change events.
+      type: string
+      enum:
+        - "org.camaraproject.qos-provisioning.v0.status-changed"
+
     CloudEvent:
       description: Event compliant with the CloudEvents specification
-      type: object
-      required:
-        - id
-        - source
-        - specversion
-        - type
-        - time
-      properties:
-        id:
-          description: Identifier of this event, that must be unique in the source context.
-          type: string
-        source:
-          description: Identifies the context in which an event happened in the specific Provider Implementation.
-          type: string
-          format: uri-reference
-        type:
-          description: The type of the event.
-          type: string
-          enum:
-            - "org.camaraproject.qos-provisioning.v0.status-changed"
-        specversion:
-          description: Version of the specification to which this event conforms (must be 1.0 if it conforms to cloudevents 1.0.2 version)
-          type: string
-          enum:
-            - "1.0"
-        datacontenttype:
-          description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
-          type: string
-          enum:
-            - "application/json"
-        data:
-          description: Event notification details payload, which depends on the event type
-          type: object
-        time:
-          description: |
-            Timestamp of when the occurrence happened. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-          type: string
-          format: date-time
+      allOf:
+        - $ref: '../common/CAMARA_event_common.yaml#/components/schemas/CloudEvent'
+        - type: object
+          properties:
+            type:
+              $ref: '#/components/schemas/ApiEventType'
       discriminator:
         propertyName: "type"
         mapping:
@@ -645,7 +518,7 @@ components:
               description: Event details depending on the event type
               required:
                 - assignmentId
-                - qosStatus
+                - status
               properties:
                 assignmentId:
                   $ref: "#/components/schemas/AssignmentId"
@@ -668,89 +541,10 @@ components:
         - DELETE_REQUESTED
 
     Device:
-      description: |
-        End-user equipment able to connect to the network. Examples of devices include smartphones or IoT sensors/actuators.
-
-        The API consumer can choose to provide the below specified device identifiers:
-
-        * `ipv4Address`
-        * `ipv6Address`
-        * `phoneNumber`
-        * `networkAccessIdentifier`
-
-        NOTE1: the network operator might support only a subset of these options. The API consumer can provide multiple identifiers to be compatible across different network operators. In this case the identifiers MUST belong to the same device.
-        NOTE2: for this Commonalities release, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
-      type: object
-      properties:
-        phoneNumber:
-          $ref: "#/components/schemas/PhoneNumber"
-        networkAccessIdentifier:
-          $ref: "#/components/schemas/NetworkAccessIdentifier"
-        ipv4Address:
-          $ref: "#/components/schemas/DeviceIpv4Addr"
-        ipv6Address:
-          $ref: "#/components/schemas/DeviceIpv6Address"
-      minProperties: 1
+      $ref: '../common/CAMARA_common.yaml#/components/schemas/Device'
 
     DeviceResponse:
-      description: |
-        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
-
-        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
-
-      allOf:
-        - $ref: "#/components/schemas/Device"
-        - maxProperties: 1
-
-    NetworkAccessIdentifier:
-      description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
-      type: string
-      example: "123456789@domain.com"
-
-    PhoneNumber:
-      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
-      type: string
-      pattern: '^\+[1-9][0-9]{4,14}$'
-      example: "+123456789"
-
-    DeviceIpv4Addr:
-      type: object
-      description: |
-        The device should be identified by either the public (observed) IP address and port as seen by the application server, or the private (local) and any public (observed) IP addresses in use by the device (this information can be obtained by various means, for example from some DNS servers).
-
-        If the allocated and observed IP addresses are the same (i.e. NAT is not in use) then  the same address should be specified for both publicAddress and privateAddress.
-
-        If NAT64 is in use, the device should be identified by its publicAddress and publicPort, or separately by its allocated IPv6 address (field ipv6Address of the Device object)
-
-        In all cases, publicAddress must be specified, along with at least one of either privateAddress or publicPort, dependent upon which is known. In general, mobile devices cannot be identified by their public IPv4 address alone.
-      properties:
-        publicAddress:
-          $ref: "#/components/schemas/SingleIpv4Addr"
-        privateAddress:
-          $ref: "#/components/schemas/SingleIpv4Addr"
-        publicPort:
-          $ref: "#/components/schemas/Port"
-      anyOf:
-        - required: [publicAddress, privateAddress]
-        - required: [publicAddress, publicPort]
-      example:
-        {
-          "publicAddress": "203.0.113.0",
-          "publicPort": 59765
-        }
-
-    SingleIpv4Addr:
-      description: A single IPv4 address with no subnet mask
-      type: string
-      format: ipv4
-      example: "203.0.113.0"
-
-    DeviceIpv6Address:
-      description: |
-        The device should be identified by the observed IPv6 address, or by any single IPv6 address from within the subnet allocated to the device (e.g. adding ::0 to the /64 prefix).
-      type: string
-      format: ipv6
-      example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+      $ref: '../common/CAMARA_common.yaml#/components/schemas/DeviceResponse'
 
     Status:
       description: |
@@ -775,56 +569,11 @@ components:
         - UNAVAILABLE
 
     ErrorInfo:
-      description: Common schema for errors
-      type: object
-      properties:
-        status:
-          type: integer
-          description: HTTP response status code
-        code:
-          type: string
-          description: A human-readable code to describe the error
-        message:
-          type: string
-          description: A human-readable description of what the event represents
-      required:
-        - status
-        - code
-        - message
+      $ref: '../common/CAMARA_common.yaml#/components/schemas/ErrorInfo'
 
   responses:
     Generic400:
-      description: Bad Request
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 400
-                  code:
-                    enum:
-                      - INVALID_ARGUMENT
-                      - OUT_OF_RANGE
-          examples:
-            GENERIC_400_INVALID_ARGUMENT:
-              description: Invalid Argument. Generic Syntax Exception
-              value:
-                status: 400
-                code: INVALID_ARGUMENT
-                message: Client specified an invalid argument, request body or query param.
-            GENERIC_400_OUT_OF_RANGE:
-              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
-              value:
-                status: 400
-                code: OUT_OF_RANGE
-                message: Client specified an invalid range.
+      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
 
     CreateAssignment400:
       description: Bad Request with additional errors for implicit notifications
@@ -879,115 +628,16 @@ components:
                 message: sink not valid for the specified protocol
 
     Generic401:
-      description: Unauthorized
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 401
-                  code:
-                    enum:
-                      - UNAUTHENTICATED
-          examples:
-            GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated and a new authentication is required
-              value:
-                status: 401
-                code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
+      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
 
     Generic403:
-      description: Forbidden
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 403
-                  code:
-                    enum:
-                      - PERMISSION_DENIED
-          examples:
-            GENERIC_403_PERMISSION_DENIED:
-              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
-              value:
-                status: 403
-                code: PERMISSION_DENIED
-                message: Client does not have sufficient permissions to perform this action.
+      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic403'
 
     Generic404:
-      description: Not found
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 404
-                  code:
-                    enum:
-                      - NOT_FOUND
-          examples:
-            GENERIC_404_NOT_FOUND:
-              description: Resource is not found
-              value:
-                status: 404
-                code: NOT_FOUND
-                message: The specified resource is not found.
+      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic404'
 
     GenericDevice404:
-      description: Not found
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 404
-                  code:
-                    enum:
-                      - NOT_FOUND
-                      - IDENTIFIER_NOT_FOUND
-          examples:
-            GENERIC_404_NOT_FOUND:
-              description: Resource is not found
-              value:
-                status: 404
-                code: NOT_FOUND
-                message: The specified resource is not found.
-            GENERIC_404_DEVICE_NOT_FOUND:
-              description: Device identifier not found
-              value:
-                status: 404
-                code: IDENTIFIER_NOT_FOUND
-                message: Device identifier not found.
+      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic404'
 
     AssignmentConflict409:
       description: Assignment conflict
@@ -1016,77 +666,10 @@ components:
                 message: There is another existing provisioning for the same device
 
     Generic410:
-      description: Gone
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 410
-                  code:
-                    enum:
-                      - GONE
-          examples:
-            GENERIC_410_GONE:
-              description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
-              value:
-                status: 410
-                code: GONE
-                message: Access to the target resource is no longer available.
+      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic410'
 
     Generic422:
-      description: Unprocessable entity
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 422
-                  code:
-                    enum:
-                      - SERVICE_NOT_APPLICABLE
-                      - MISSING_IDENTIFIER
-                      - UNSUPPORTED_IDENTIFIER
-                      - UNNECESSARY_IDENTIFIER
-          examples:
-            GENERIC_422_SERVICE_NOT_APPLICABLE:
-              description: Service not applicable for the provided identifier
-              value:
-                status: 422
-                code: SERVICE_NOT_APPLICABLE
-                message: The service is not available for the provided identifier.
-            GENERIC_422_MISSING_IDENTIFIER:
-              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the access token
-              value:
-                status: 422
-                code: MISSING_IDENTIFIER
-                message: The device cannot be identified.
-            GENERIC_422_UNSUPPORTED_IDENTIFIER:
-              description: None of the provided identifiers is supported by the implementation
-              value:
-                status: 422
-                code: UNSUPPORTED_IDENTIFIER
-                message: The identifier provided is not supported.
-            GENERIC_422_UNNECESSARY_IDENTIFIER:
-              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
-              value:
-                status: 422
-                code: UNNECESSARY_IDENTIFIER
-                message: The device is already identified by the access token.ç
+      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic422'
 
     CreateAssignment422:
       description: Unprocessable Content
@@ -1143,37 +726,7 @@ components:
                 message: The requested QoS Profile is not compatible with the QoS Provisioning service.
 
     Generic429:
-      description: Too Many Requests
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 429
-                  code:
-                    enum:
-                      - QUOTA_EXCEEDED
-                      - TOO_MANY_REQUESTS
-          examples:
-            GENERIC_429_QUOTA_EXCEEDED:
-              description: Request is rejected due to exceeding a business quota limit
-              value:
-                status: 429
-                code: QUOTA_EXCEEDED
-                message: Out of resource quota.
-            GENERIC_429_TOO_MANY_REQUESTS:
-              description: Access to the API has been temporarily blocked due to rate or spike arrest limits being reached
-              value:
-                status: 429
-                code: TOO_MANY_REQUESTS
-                message: Rate limit reached.
+      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic429'
 
   examples:
     ASSIGNMENT_CREATION_EXAMPLE:

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -196,7 +196,7 @@ paths:
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "#/components/responses/GenericDevice404"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
         "409":
           $ref: "#/components/responses/AssignmentConflict409"
         "422":
@@ -247,7 +247,7 @@ paths:
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "#/components/responses/Generic404"
+          $ref: "#/components/responses/NotFound404"
         "429":
           $ref: "#/components/responses/Generic429"
       security:
@@ -296,7 +296,7 @@ paths:
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "#/components/responses/Generic404"
+          $ref: "#/components/responses/NotFound404"
         "429":
           $ref: "#/components/responses/Generic429"
       security:
@@ -354,7 +354,7 @@ paths:
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "#/components/responses/GenericDevice404"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
         "422":
           $ref: "#/components/responses/Generic422"
         "429":
@@ -633,11 +633,31 @@ components:
     Generic403:
       $ref: '../common/CAMARA_common.yaml#/components/responses/Generic403'
 
-    Generic404:
-      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic404'
-
-    GenericDevice404:
-      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic404'
+    NotFound404:
+      description: Not found
+      headers:
+        x-correlator:
+          $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '../common/CAMARA_common.yaml#/components/schemas/ErrorInfo'
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+          examples:
+            GENERIC_404_NOT_FOUND:
+              description: Resource is not found
+              value:
+                status: 404
+                code: NOT_FOUND
+                message: The specified resource is not found.
 
     AssignmentConflict409:
       description: Assignment conflict

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -78,6 +78,7 @@ info:
     <!-- CAMARA:MANDATORY:additional-error-responses:END -->
 
     <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+
     # Request body strictness
 
     This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -132,7 +132,7 @@ paths:
 
       operationId: createQosAssignment
       parameters:
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: '../common/CAMARA_common.yaml#/components/parameters/x-correlator'
       requestBody:
         description: Parameters to assign a QoS profile to a device
         content:
@@ -151,7 +151,7 @@ paths:
                 Currently only `ASSIGNMENT_STATUS_CHANGED` event is defined.
               operationId: postQosAssignmentNotification
               parameters:
-                - $ref: "#/components/parameters/x-correlator"
+                - $ref: '../common/CAMARA_common.yaml#/components/parameters/x-correlator'
               requestBody:
                 required: true
                 content:
@@ -166,17 +166,17 @@ paths:
                   description: Successful notification
                   headers:
                     x-correlator:
-                      $ref: "#/components/headers/x-correlator"
+                      $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
                 "400":
-                  $ref: "#/components/responses/Generic400"
+                  $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
                 "401":
-                  $ref: "#/components/responses/Generic401"
+                  $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
                 "403":
                   $ref: "#/components/responses/PermissionDenied403"
                 "410":
-                  $ref: "#/components/responses/Generic410"
+                  $ref: '../common/CAMARA_common.yaml#/components/responses/Generic410'
                 "429":
-                  $ref: "#/components/responses/Generic429"
+                  $ref: '../common/CAMARA_common.yaml#/components/responses/Generic429'
               security:
                 - {}
                 - notificationsBearerAuth: []
@@ -185,7 +185,7 @@ paths:
           description: Assignment created
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
           content:
             application/json:
               schema:
@@ -198,7 +198,7 @@ paths:
         "400":
           $ref: "#/components/responses/CreateAssignment400"
         "401":
-          $ref: "#/components/responses/Generic401"
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
         "403":
           $ref: "#/components/responses/PermissionDenied403"
         "404":
@@ -208,7 +208,7 @@ paths:
         "422":
           $ref: "#/components/responses/CreateAssignment422"
         "429":
-          $ref: "#/components/responses/Generic429"
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic429'
       security:
         - openId:
             - "qos-provisioning:qos-assignments:create"
@@ -228,13 +228,13 @@ paths:
       operationId: getQosAssignmentById
       parameters:
         - $ref: "#/components/parameters/assignmentId"
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: '../common/CAMARA_common.yaml#/components/parameters/x-correlator'
       responses:
         "200":
           description: Returns information about certain assignment
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
           content:
             application/json:
               schema:
@@ -247,15 +247,15 @@ paths:
                 ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE:
                   $ref: "#/components/examples/ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE"
         "400":
-          $ref: "#/components/responses/Generic400"
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
         "401":
-          $ref: "#/components/responses/Generic401"
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
         "403":
           $ref: "#/components/responses/PermissionDenied403"
         "404":
           $ref: "#/components/responses/NotFound404"
         "429":
-          $ref: "#/components/responses/Generic429"
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic429'
       security:
         - openId:
             - "qos-provisioning:qos-assignments:read"
@@ -279,32 +279,32 @@ paths:
       operationId: revokeQosAssignment
       parameters:
         - $ref: "#/components/parameters/assignmentId"
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: '../common/CAMARA_common.yaml#/components/parameters/x-correlator'
       responses:
         "204":
           description: Assignment revoked
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
         "202":
           description: Deletion request accepted to be processed. It applies for an async deletion process. `status` in the response will be `AVAILABLE` with `statusInfo` set to `DELETE_REQUESTED`.
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/AssignmentInfo"
         "400":
-          $ref: "#/components/responses/Generic400"
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
         "401":
-          $ref: "#/components/responses/Generic401"
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
         "403":
           $ref: "#/components/responses/PermissionDenied403"
         "404":
           $ref: "#/components/responses/NotFound404"
         "429":
-          $ref: "#/components/responses/Generic429"
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic429'
       security:
         - openId:
             - "qos-provisioning:qos-assignments:delete"
@@ -327,7 +327,7 @@ paths:
 
       operationId: getQosAssignmentByDevice
       parameters:
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: '../common/CAMARA_common.yaml#/components/parameters/x-correlator'
       requestBody:
         description: Parameters to retrieve an assignment record by device
         content:
@@ -341,7 +341,7 @@ paths:
 
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
           content:
             application/json:
               schema:
@@ -354,17 +354,17 @@ paths:
                 ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE:
                   $ref: "#/components/examples/ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE"
         "400":
-          $ref: "#/components/responses/Generic400"
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
         "401":
-          $ref: "#/components/responses/Generic401"
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
         "403":
           $ref: "#/components/responses/PermissionDenied403"
         "404":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
         "422":
-          $ref: "#/components/responses/Generic422"
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic422'
         "429":
-          $ref: "#/components/responses/Generic429"
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic429'
       security:
         - openId:
             - "qos-provisioning:qos-assignments:read-by-device"
@@ -372,14 +372,9 @@ paths:
 components:
   securitySchemes:
     openId:
-      description: OpenID Connect authentication
-      type: openIdConnect
-      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+      $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
     notificationsBearerAuth:
-      description: Bearer authentication for notifications
-      type: http
-      scheme: bearer
-      bearerFormat: "{$request.body#/sinkCredential.credentialType}"
+      $ref: "../common/CAMARA_event_common.yaml#/components/securitySchemes/notificationsBearerAuth"
 
   parameters:
     assignmentId:
@@ -389,13 +384,6 @@ components:
       required: true
       schema:
         $ref: "#/components/schemas/AssignmentId"
-
-    x-correlator:
-      $ref: '../common/CAMARA_common.yaml#/components/parameters/x-correlator'
-
-  headers:
-    x-correlator:
-      $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
 
   schemas:
     AssignmentId:
@@ -560,14 +548,11 @@ components:
         - UNAVAILABLE
 
   responses:
-    Generic400:
-      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
-
     CreateAssignment400:
       description: Bad Request with additional errors for implicit notifications
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
       content:
         application/json:
           schema:
@@ -614,9 +599,6 @@ components:
                 status: 400
                 code: INVALID_SINK
                 message: sink not valid for the specified protocol
-
-    Generic401:
-      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
 
     PermissionDenied403:
       description: Forbidden
@@ -674,7 +656,7 @@ components:
       description: Assignment conflict
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
       content:
         application/json:
           schema:
@@ -696,17 +678,11 @@ components:
                 code: CONFLICT
                 message: There is another existing provisioning for the same device
 
-    Generic410:
-      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic410'
-
-    Generic422:
-      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic422'
-
     CreateAssignment422:
       description: Unprocessable Content
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
       content:
         application/json:
           schema:
@@ -762,9 +738,6 @@ components:
                 status: 422
                 code: QOS_PROVISIONING.QOS_PROFILE_NOT_APPLICABLE
                 message: The requested QoS Profile is not compatible with the QoS Provisioning service.
-
-    Generic429:
-      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic429'
 
   examples:
     ASSIGNMENT_CREATION_EXAMPLE:

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -31,6 +31,7 @@ info:
     - An operation to revoke the assignment of a QoS profile to a given device, identified by the `assignmentId`.
 
     <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
+
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -41,6 +41,7 @@ info:
     <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
     <!-- CAMARA:MANDATORY:identifying-device-from-access-token:BEGIN -->
+
     # Identifying the device from the access token
 
     This API requires the API consumer to identify a device as the subject of the API as follows:

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -735,6 +735,7 @@ components:
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
+                      - PRIVATE_KEY_JWT_NOT_CONFIGURED
                       - QOS_PROVISIONING.QOS_PROFILE_NOT_APPLICABLE
           examples:
             GENERIC_422_SERVICE_NOT_APPLICABLE:
@@ -761,6 +762,12 @@ components:
                 status: 422
                 code: UNNECESSARY_IDENTIFIER
                 message: The device is already identified by the access token.
+            GENERIC_422_PRIVATE_KEY_JWT_NOT_CONFIGURED:
+              description: No JWK Set configured for PRIVATE_KEY_JWT authentication
+              value:
+                status: 422
+                code: PRIVATE_KEY_JWT_NOT_CONFIGURED
+                message: No JWK Set configured for PRIVATE_KEY_JWT authentication.
             QOS_PROVISIONING_422_QOS_PROFILE_NOT_APPLICABLE:
               description: The requested QoS Profile exists but cannot be used for the QoS assignment.
               value:

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -69,6 +69,7 @@ info:
     - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device, and use the secondary phone number to identify the intended device if available.
 
     <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
+
     # Additional CAMARA error responses
 
     The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -20,7 +20,7 @@ info:
       Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Notification URL and token**:
-    API consumers may provide a callback URL (`sink`) on which notifications about all status change events (eg. assignment termination) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message. If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint.
+    API consumers may provide a callback URL (`sink`) on which notifications about all status change events (eg. assignment termination) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message. If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint. If provided, `sinkCredential.credentialType` MUST be set to `ACCESSTOKEN` or `PRIVATE_KEY_JWT`.
 
     # Resources and Operations overview
     The API defines four operations:

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -166,7 +166,7 @@ paths:
                 "401":
                   $ref: "#/components/responses/Generic401"
                 "403":
-                  $ref: "#/components/responses/Generic403"
+                  $ref: "#/components/responses/PermissionDenied403"
                 "410":
                   $ref: "#/components/responses/Generic410"
                 "429":
@@ -194,7 +194,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/PermissionDenied403"
         "404":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
         "409":
@@ -245,7 +245,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/PermissionDenied403"
         "404":
           $ref: "#/components/responses/NotFound404"
         "429":
@@ -294,7 +294,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/PermissionDenied403"
         "404":
           $ref: "#/components/responses/NotFound404"
         "429":
@@ -352,7 +352,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/PermissionDenied403"
         "404":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
         "422":
@@ -630,8 +630,31 @@ components:
     Generic401:
       $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
 
-    Generic403:
-      $ref: '../common/CAMARA_common.yaml#/components/responses/Generic403'
+    PermissionDenied403:
+      description: Forbidden
+      headers:
+        x-correlator:
+          $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '../common/CAMARA_common.yaml#/components/schemas/ErrorInfo'
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 403
+                  code:
+                    enum:
+                      - PERMISSION_DENIED
+          examples:
+            GENERIC_403_PERMISSION_DENIED:
+              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
+              value:
+                status: 403
+                code: PERMISSION_DENIED
+                message: Client does not have sufficient permissions to perform this action.
 
     NotFound404:
       description: Not found

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -40,19 +40,21 @@ info:
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
     <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
+    <!-- CAMARA:MANDATORY:identifying-device-from-access-token:BEGIN -->
     # Identifying the device from the access token
 
     This API requires the API consumer to identify a device as the subject of the API as follows:
     - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
-
     - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.
 
     This approach simplifies API usage for API consumers using a three-legged access token to invoke the API by relying on the information that is associated with the access token and was identified during the authentication process.
 
     ## Error handling:
+
     - If the subject cannot be identified from the access token and the optional `device` object is not included in the request, then the server will return an error with the `422 MISSING_IDENTIFIER` error code.
 
     - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
+    <!-- CAMARA:MANDATORY:identifying-device-from-access-token:END -->
 
     - If the requested `qosProfile` exists but is currently not available or incompatible for the QoS assignment (e.g., its status is INACTIVE or DEPRECATED, or its characteristics are not compatible with QoS Provisioning service), then the server will return an error with the `422 QOS_PROVISIONING.QOS_PROFILE_NOT_APPLICABLE` error code.
 
@@ -151,7 +153,7 @@ paths:
                 content:
                   application/cloudevents+json:
                     schema:
-                      $ref: "#/components/schemas/CloudEvent"
+                      $ref: "#/components/schemas/QosProvisioningNotificationEvent"
                     examples:
                       ASSIGNMENT_STATUS_CHANGED_EXAMPLE:
                         $ref: "#/components/examples/ASSIGNMENT_STATUS_CHANGED_EXAMPLE"
@@ -403,7 +405,7 @@ components:
       type: object
       properties:
         device:
-          $ref: "#/components/schemas/Device"
+          $ref: '../common/CAMARA_common.yaml#/components/schemas/Device'
         qosProfile:
           $ref: "#/components/schemas/QosProfileName"
         sink:
@@ -414,7 +416,7 @@ components:
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         sinkCredential:
-          $ref: "#/components/schemas/SinkCredential"
+          $ref: '../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential'
       required:
         - qosProfile
 
@@ -428,7 +430,7 @@ components:
         - type: object
           properties:
             device:
-              $ref: "#/components/schemas/DeviceResponse"
+              $ref: '../common/CAMARA_common.yaml#/components/schemas/DeviceResponse'
         - $ref: "#/components/schemas/BaseAssignmentInfo"
         - type: object
           properties:
@@ -454,7 +456,7 @@ components:
         - type: object
           properties:
             device:
-              $ref: "#/components/schemas/Device"
+              $ref: '../common/CAMARA_common.yaml#/components/schemas/Device'
         - $ref: "#/components/schemas/BaseAssignmentInfo"
 
     RetrieveAssignmentByDevice:
@@ -462,16 +464,7 @@ components:
       type: object
       properties:
         device:
-          $ref: "#/components/schemas/Device"
-
-    SinkCredential:
-      $ref: '../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential'
-
-    AccessTokenCredential:
-      $ref: '../common/CAMARA_event_common.yaml#/components/schemas/AccessTokenCredential'
-
-    PrivateKeyJWTCredential:
-      $ref: '../common/CAMARA_event_common.yaml#/components/schemas/PrivateKeyJWTCredential'
+          $ref: '../common/CAMARA_common.yaml#/components/schemas/Device'
 
     QosProfileName:
       description: |
@@ -488,20 +481,20 @@ components:
       maxLength: 256
       pattern: "^[a-zA-Z0-9_.-]+$"
 
-    ApiEventType:
+    QosProvisioningEventType:
       description: The type identifier for QoS provisioning status-change events.
       type: string
       enum:
         - "org.camaraproject.qos-provisioning.v0.status-changed"
 
-    CloudEvent:
+    QosProvisioningNotificationEvent:
       description: Event compliant with the CloudEvents specification
       allOf:
         - $ref: '../common/CAMARA_event_common.yaml#/components/schemas/CloudEvent'
         - type: object
           properties:
             type:
-              $ref: '#/components/schemas/ApiEventType'
+              $ref: '#/components/schemas/QosProvisioningEventType'
       discriminator:
         propertyName: "type"
         mapping:
@@ -510,7 +503,7 @@ components:
     EventStatusChanged:
       description: Event to notify a QoS provisioning status change
       allOf:
-        - $ref: "#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/QosProvisioningNotificationEvent"
         - type: object
           properties:
             data:
@@ -540,12 +533,6 @@ components:
         - NETWORK_TERMINATED
         - DELETE_REQUESTED
 
-    Device:
-      $ref: '../common/CAMARA_common.yaml#/components/schemas/Device'
-
-    DeviceResponse:
-      $ref: '../common/CAMARA_common.yaml#/components/schemas/DeviceResponse'
-
     Status:
       description: |
         The current status of the requested QoS profile assignment. The status can be one of the following:
@@ -568,9 +555,6 @@ components:
         - AVAILABLE
         - UNAVAILABLE
 
-    ErrorInfo:
-      $ref: '../common/CAMARA_common.yaml#/components/schemas/ErrorInfo'
-
   responses:
     Generic400:
       $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
@@ -584,7 +568,7 @@ components:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: '../common/CAMARA_common.yaml#/components/schemas/ErrorInfo'
               - type: object
                 properties:
                   status:
@@ -691,7 +675,7 @@ components:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: '../common/CAMARA_common.yaml#/components/schemas/ErrorInfo'
               - type: object
                 properties:
                   status:
@@ -723,7 +707,7 @@ components:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: '../common/CAMARA_common.yaml#/components/schemas/ErrorInfo'
               - type: object
                 properties:
                   status:

--- a/code/Test_definitions/qos-provisioning-createQosAssignment.feature
+++ b/code/Test_definitions/qos-provisioning-createQosAssignment.feature
@@ -105,7 +105,7 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
     Examples:
       | device_identifier                | oas_spec_schema                             |
       | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
-      | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+      | $.device.ipv4Address             | /components/schemas/DeviceIpv4Address       |
       | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
       | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
@@ -197,16 +197,17 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  # PLAIN and REFRESHTOKEN are considered in the schema so INVALID_ARGUMENT is not expected
+  # PLAIN and REFRESHTOKEN were removed from the schema in r4.3; any value outside the
+  # ACCESSTOKEN / PRIVATE_KEY_JWT enum produces INVALID_ARGUMENT.
   @qos_provisioning_createQosAssignment_400.7_invalid_sink_credential
-  Scenario Outline: Invalid credential
+  Scenario Outline: Invalid credential type
     Given the request body property  "$.sinkCredential.credentialType" is set to "<unsupported_credential_type>"
     When the request "createQosAssignment" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 400
-    And the response property "$.code" is "INVALID_CREDENTIAL"
+    And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
     Examples:
@@ -238,6 +239,14 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
+
+  @qos_provisioning_createQosAssignment_400.10_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "#/components/schemas/XCorrelator"
+    When the request "createQosAssignment" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
 
   # Generic 401 errors
 
@@ -279,7 +288,7 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
 
   @qos_provisioning_createQosAssignment_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope qos-provisioning:qos-assignments:create
+    Given the header "Authorization" is set to an access token that does not include scope "qos-provisioning:qos-assignments:create"
     When the request "createQosAssignment" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -313,4 +322,18 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 422
     And the response property "$.code" is "QOS_PROVISIONING.QOS_PROFILE_NOT_APPLICABLE"
+    And the response property "$.message" contains a user friendly text
+
+  # Errors 429
+
+  @qos_provisioning_createQosAssignment_429.1_too_many_requests
+  # To test this scenario the environment has to be configured to reject requests reaching the threshold limit set.
+  Scenario: Request is rejected due to threshold policy
+    Given a valid request for "createQosAssignment"
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the request "createQosAssignment" is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/qos-provisioning-createQosAssignment.feature
+++ b/code/Test_definitions/qos-provisioning-createQosAssignment.feature
@@ -324,6 +324,19 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation createQosAssignment
     And the response property "$.code" is "QOS_PROVISIONING.QOS_PROFILE_NOT_APPLICABLE"
     And the response property "$.message" contains a user friendly text
 
+  @qos_provisioning_createQosAssignment_422.2_private_key_jwt_not_configured
+  Scenario: PRIVATE_KEY_JWT sink credential used but not pre-configured
+    Given a valid testing device supported by the service, identified by the token or provided in the request body
+    And the request body property "$.sinkCredential.credentialType" is set to "PRIVATE_KEY_JWT"
+    And no PRIVATE_KEY_JWT configuration has been pre-shared for the notification endpoint
+    When the request "createQosAssignment" is sent
+    Then the response status code is 422
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 422
+    And the response property "$.code" is "PRIVATE_KEY_JWT_NOT_CONFIGURED"
+    And the response property "$.message" contains a user friendly text
+
   # Errors 429
 
   @qos_provisioning_createQosAssignment_429.1_too_many_requests

--- a/code/Test_definitions/qos-provisioning-getQosAssignmentByDevice.feature
+++ b/code/Test_definitions/qos-provisioning-getQosAssignmentByDevice.feature
@@ -65,7 +65,7 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentByDevice
     Examples:
       | device_identifier                | oas_spec_schema                             |
       | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
-      | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+      | $.device.ipv4Address             | /components/schemas/DeviceIpv4Address       |
       | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
       | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
@@ -145,6 +145,14 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentByDevice
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  @qos_provisioning_getQosAssignmentByDevice_400.10_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "#/components/schemas/XCorrelator"
+    When the request "getQosAssignmentByDevice" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
   # Generic 401 errors
 
   @qos_provisioning_getQosAssignmentByDevice_401.1_no_authorization_header
@@ -185,7 +193,7 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentByDevice
 
   @qos_provisioning_getQosAssignmentByDevice_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope qos-provisioning:qos-assignments:read-by-device
+    Given the header "Authorization" is set to an access token that does not include scope "qos-provisioning:qos-assignments:read-by-device"
     When the request "getQosAssignmentByDevice" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -217,4 +225,18 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentByDevice
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+
+  # Errors 429
+
+  @qos_provisioning_getQosAssignmentByDevice_429.1_too_many_requests
+  # To test this scenario the environment has to be configured to reject requests reaching the threshold limit set.
+  Scenario: Request is rejected due to threshold policy
+    Given a valid request for "getQosAssignmentByDevice"
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the request "getQosAssignmentByDevice" is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/qos-provisioning-getQosAssignmentById.feature
+++ b/code/Test_definitions/qos-provisioning-getQosAssignmentById.feature
@@ -63,6 +63,14 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentById
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  @qos_provisioning_getQosAssignmentById_400.10_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "#/components/schemas/XCorrelator"
+    When the request "getQosAssignmentById" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
   # Generic 401 errors
 
   @qos_provisioning_getQosAssignmentById_401.1_no_authorization_header
@@ -103,7 +111,7 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentById
 
   @qos_provisioning_getQosAssignmentById_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope qos-provisioning:qos-assignments:read
+    Given the header "Authorization" is set to an access token that does not include scope "qos-provisioning:qos-assignments:read"
     When the request "getQosAssignmentById" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -135,4 +143,18 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation getQosAssignmentById
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+
+  # Errors 429
+
+  @qos_provisioning_getQosAssignmentById_429.1_too_many_requests
+  # To test this scenario the environment has to be configured to reject requests reaching the threshold limit set.
+  Scenario: Request is rejected due to threshold policy
+    Given a valid request for "getQosAssignmentById"
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the request "getQosAssignmentById" is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/qos-provisioning-revokeQosAssignment.feature
+++ b/code/Test_definitions/qos-provisioning-revokeQosAssignment.feature
@@ -101,6 +101,14 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation revokeQosAssignment
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  @qos_provisioning_revokeQosAssignment_400.10_invalid_x-correlator
+  Scenario: Invalid x-correlator header
+    Given the header "x-correlator" does not comply with the schema at "#/components/schemas/XCorrelator"
+    When the request "revokeQosAssignment" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
   # Generic 401 errors
 
   @qos_provisioning_revokeQosAssignment_401.1_no_authorization_header
@@ -141,7 +149,7 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation revokeQosAssignment
 
   @qos_provisioning_revokeQosAssignment_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope qos-provisioning:qos-assignments:delete
+    Given the header "Authorization" is set to an access token that does not include scope "qos-provisioning:qos-assignments:delete"
     When the request "revokeQosAssignment" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -173,4 +181,18 @@ Feature: CAMARA QoS Provisioning API, vwip - Operation revokeQosAssignment
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+
+  # Errors 429
+
+  @qos_provisioning_revokeQosAssignment_429.1_too_many_requests
+  # To test this scenario the environment has to be configured to reject requests reaching the threshold limit set.
+  Scenario: Request is rejected due to threshold policy
+    Given a valid request for "revokeQosAssignment"
+    And the header "Authorization" is set to a valid access token
+    And the threshold of requests has been reached
+    When the request "revokeQosAssignment" is sent
+    Then the response status code is 429
+    And the response property "$.status" is 429
+    And the response property "$.code" is "TOO_MANY_REQUESTS"
     And the response property "$.message" contains a user friendly text


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Aligns `qos-provisioning.yaml` with CAMARA Commonalities r4.3 (0.8.0).

**Info description templates (P-026)**
- Adds the three mandatory `info.description` template blocks with their HTML comment markers: `authorization-and-authentication`, `additional-error-responses`, and `request-body-strictness` (new in r4.3).
- Updates `x-camara-commonalities` from `0.6` to `0.8.0`.

**Schema $ref migration — CAMARA_common.yaml**
- Replaces locally-defined `Device`, `DeviceResponse`, and `ErrorInfo` schemas with `$ref` aliases pointing to `code/common/CAMARA_common.yaml`.
- Replaces the `x-correlator` parameter and header definitions with `$ref`s to the common file.
- Removes the now-redundant local copies of `XCorrelator`, `NetworkAccessIdentifier`, `PhoneNumber`, `DeviceIpv4Address`, `SingleIpv4Address`, `DeviceIpv6Address`, and `Port`.
- Replaces all `Generic4xx`/`5xx` error responses with `$ref`s to `CAMARA_common.yaml`; API-specific responses (`CreateAssignment400`, `AssignmentConflict409`, `CreateAssignment422`) are retained locally.

**Schema $ref migration — CAMARA_event_common.yaml (P-020, P-015)**
- Replaces the inline `CloudEvent` definition with an `allOf` composition referencing `code/common/CAMARA_event_common.yaml#/components/schemas/CloudEvent`, extended with a local `ApiEventType` schema (single named enum, as required by P-015).
- Replaces `SinkCredential` and `AccessTokenCredential` with `$ref` aliases to `CAMARA_event_common.yaml`; adds `PrivateKeyJWTCredential` as a `$ref` alias.
- Removes `PlainCredential` and `RefreshTokenCredential` (deprecated/removed in Commonalities r4.3).

**Bug fix (S-030)**
- Corrects `EventStatusChanged.data.required`: `qosStatus` → `status`, aligning the required array with the actual property name.

**Schema constraints (S-312, S-311, S-310)**
- Adds `maxLength: 36` to `AssignmentId` (UUID format).
- Adds `maxLength: 2048` to `BaseAssignmentInfo.sink` (URI).
- Adds `maxLength: 64` to `AssignmentInfo.startedAt` (date-time).
- Remaining S-312/S-311/S-310 warnings on migrated schemas (ErrorInfo, CloudEvent, credential types) are resolved transitively through the common-file $refs.

- Test plan updated

#### Which issue(s) this PR fixes:

Fixes #572

#### Special notes for reviewers:

- The credential model changes from `{PLAIN, ACCESSTOKEN, REFRESHTOKEN}` to `{ACCESSTOKEN, PRIVATE_KEY_JWT}` as defined in `CAMARA_event_common.yaml` r4.3. This is a breaking change for consumers using `PLAIN` or `REFRESHTOKEN` credential types; those types were already marked "MUST not be used" in the previous version.

#### Changelog input

```
release-note

API qos-provisioning & test plan: aligned with CAMARA Commonalities r4.3 (0.8.0)
```

#### Additional documentation

This section can be blank.

