### PR TITLE
fix(qos-profiles): give the two 404 responses non-conflicting names

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -140,7 +140,7 @@ paths:
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "#/components/responses/GenericDevice404"
+          $ref: "#/components/responses/RetrieveQosProfilesNotFound404"
         "422":
           $ref: "#/components/responses/Generic422"
         "429":
@@ -185,7 +185,7 @@ paths:
         "403":
           $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "#/components/responses/Generic404"
+          $ref: "#/components/responses/NotFound404"
         "429":
           $ref: "#/components/responses/Generic429"
 
@@ -545,7 +545,7 @@ components:
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
 
-    Generic404:
+    NotFound404:
       description: Not found
       headers:
         x-correlator:
@@ -571,8 +571,38 @@ components:
                 code: NOT_FOUND
                 message: The specified resource is not found.
 
-    GenericDevice404:
-      $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
+    RetrieveQosProfilesNotFound404:
+      description: Not found
+      headers:
+        x-correlator:
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+                      - IDENTIFIER_NOT_FOUND
+          examples:
+            GENERIC_404_NOT_FOUND:
+              description: Resource is not found
+              value:
+                status: 404
+                code: NOT_FOUND
+                message: The specified resource is not found.
+            GENERIC_404_IDENTIFIER_NOT_FOUND:
+              description: Some identifier cannot be matched to a device
+              value:
+                status: 404
+                code: IDENTIFIER_NOT_FOUND
+                message: Device identifier not found.
 
     Generic422:
       description: Unprocessable Content


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

`qos-profiles.yaml` had two different response bodies competing for the name `Generic404`: a local `NOT_FOUND`-only definition used by `getQosProfile`, and a `GenericDevice404` component that was a pure alias to the common `Generic404` (`NOT_FOUND` + `IDENTIFIER_NOT_FOUND`) used by `retrieveQoSProfiles`. Bundling must inline the common response under its own name, but the local definition held it, so redocly emitted a `Generic404-2` component, repointed the `retrieveQoSProfiles` use-site at it, and left `GenericDevice404` orphaned — surfacing as an unused-component warning on the bundled spec. This gives each 404 a non-conflicting, self-describing name and defines both locally: `NotFound404` for `getQosProfile` and `RetrieveQosProfilesNotFound404` for `retrieveQoSProfiles`.

* No `Generic404-2` in the bundled spec, and the unused-component warning is gone.
* No dependency on `Generic404`, which is deprecated in Commonalities 0.9.0 and slated for removal.
* The wire contract is unchanged: `retrieveQoSProfiles` still documents `NOT_FOUND` + `IDENTIFIER_NOT_FOUND`, `getQosProfile` still `NOT_FOUND` only.

#### Which issue(s) this PR fixes:

Fixes #589

#### Special notes for reviewers:

The warning only exists after bundling — in the source spec the alias is genuinely referenced — so it appears on release-review runs rather than ordinary branch runs. To reproduce, bundle `code/API_definitions/qos-profiles.yaml` with `redocly bundle` before and after this change and lint both outputs with `.spectral-r4.yaml`.

`RetrieveQosProfilesNotFound404` deliberately avoids any name in the Commonalities catalogue, whose 404s are `NotFound404` (`NOT_FOUND`) and `IdentifierNotFound404` (`IDENTIFIER_NOT_FOUND`) separately. Reusing a catalogue name for a different code set is what caused this collision.

Whether `retrieveQoSProfiles` should document `NOT_FOUND` at all is a separate question, not touched here.

#### Changelog input

```
 release-note
Fix a 404 response component name collision in qos-profiles introduced by #575; not present in any release.
```

#### Additional documentation

This section can be blank.

```
docs

```
