### PR TITLE
Chore/593 update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @hdamker @eric-murray @RandyLevensalor @jlurien
+* @hdamker @eric-murray @benhepworth @jlurien
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management

#### What this PR does / why we need it:

Swap Randy Levensalor for Ben Hepworth as code owner.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #593 

#### Special notes for reviewers:

Randy will stay on as Maintainer and will still be around if we need him. Just moving Code Owner responsibilities from Randy to Ben.

#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
