### PR TITLE
Correct externalDocs.description wording in qos-provisioning.yaml

### DIFF
--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -94,7 +94,7 @@ info:
   x-camara-commonalities: 0.8.0
 
 externalDocs:
-  description: Project documentation at CAMARA
+  description: Product documentation at CAMARA
   url: https://github.com/camaraproject/QualityOnDemand
 
 servers:


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

`externalDocs.description` in `qos-provisioning.yaml` read "Project documentation at CAMARA" instead of "Product documentation at CAMARA" (Design Guide §5.4). The other two API definitions in this repo already use the correct wording.

#### Which issue(s) this PR fixes:

None

#### Special notes for reviewers:

One-line fix, no behavior change.

#### Changelog input

```
release-note
Fix externalDocs.description wording in qos-provisioning.yaml.
```

#### Additional documentation

This section can be blank.

```
docs

```
