### PR TITLE
[Changed] Remove device property from SessionInfo and Assignment Info and add to new additional schemas

### DIFF
--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -396,8 +396,6 @@ components:
       description: Common attributes of the assignment record for a QoS profile assignment
       type: object
       properties:
-        device:
-          $ref: '../common/CAMARA_common.yaml#/components/schemas/Device'
         qosProfile:
           $ref: "#/components/schemas/QosProfileName"
         sink:

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -350,7 +350,7 @@ paths:
                 ASSIGNMENT_UNAVAILABLE:
                   $ref: "#/components/examples/ASSIGNMENT_UNAVAILABLE"
                 ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE:
-                  $ref: "#/components/examples/ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE"
+                  $ref: "#/components/examples/ASSIGNMENT_AVAILABLE_WITH_DEVICE"
         "400":
           $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
         "401":
@@ -779,6 +779,21 @@ components:
       summary: QoS assignment status is available
       description: Device is optional in responses and must not be provided if it was not provided in the request
       value:
+        qosProfile: QOS_M
+        sink: https://application-server.com/callback
+        sinkCredential:
+          credentialType: ACCESSTOKEN
+          accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
+        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        startedAt: "2024-05-12T17:32:01Z"
+        status: AVAILABLE
+
+    ASSIGNMENT_AVAILABLE_WITH_DEVICE:
+      summary: QoS assignment status is available
+      description: Device is optional in responses and must not be provided if it was not provided in the request
+      value:
+        device:
+          phoneNumber: "+123456789"
         qosProfile: QOS_M
         sink: https://application-server.com/callback
         sinkCredential:

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -189,7 +189,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AssignmentInfo"
+                $ref: "#/components/schemas/AssignmentInfoWithDevice"
               examples:
                 Successful QoS Profile Assignment Creation:
                   $ref: "#/components/examples/ASSIGNMENT_CREATION_EXAMPLE"
@@ -345,7 +345,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AssignmentInfo"
+                $ref: "#/components/schemas/AssignmentInfoWithDevice"
               examples:
                 ASSIGNMENT_AVAILABLE:
                   $ref: "#/components/examples/ASSIGNMENT_AVAILABLE"
@@ -419,10 +419,6 @@ components:
         Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time the QoS profile assignment was created.
 
       allOf:
-        - type: object
-          properties:
-            device:
-              $ref: '../common/CAMARA_common.yaml#/components/schemas/DeviceResponse'
         - $ref: "#/components/schemas/BaseAssignmentInfo"
         - type: object
           properties:
@@ -441,6 +437,15 @@ components:
           required:
             - assignmentId
             - status
+
+    AssignmentInfoWithDevice:
+      description: Assignment information plus an optional `device` property, which is only required to allow the API consumer to disambiguate which device identifier applies when more than one identifier is provided in the request.
+      allOf:
+        - type: object
+          properties:
+            device:
+              $ref: '../common/CAMARA_common.yaml#/components/schemas/DeviceResponse'
+        - $ref: "#/components/schemas/AssignmentInfo"
 
     CreateAssignment:
       description: Attributes to request a new QoS profile assignment

--- a/code/API_definitions/qos-provisioning.yaml
+++ b/code/API_definitions/qos-provisioning.yaml
@@ -244,8 +244,6 @@ paths:
                   $ref: "#/components/examples/ASSIGNMENT_AVAILABLE"
                 ASSIGNMENT_UNAVAILABLE:
                   $ref: "#/components/examples/ASSIGNMENT_UNAVAILABLE"
-                ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE:
-                  $ref: "#/components/examples/ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE"
         "400":
           $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
         "401":
@@ -763,23 +761,6 @@ components:
         assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         status: REQUESTED
 
-    ASSIGNMENT_AVAILABLE:
-      summary: QoS assignment status is available with device in the assignment details
-      description: The QoS profile assignment has become available, and the device to which the assignment applies is included in the assignment details
-      value:
-        device:
-          phoneNumber: "+123456789"
-        qosProfile: QOS_L
-        sink: https://application-server.com/callback
-        sinkCredential:
-          credentialType: ACCESSTOKEN
-          accessToken: "eyJhbGciOiJIUzI1NiIsInR..."
-          accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
-          accessTokenType: bearer
-        assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
-        startedAt: "2024-05-12T17:32:01Z"
-        status: AVAILABLE
-
     ASSIGNMENT_UNAVAILABLE:
       summary: QoD provisioning status is unavailable
       description: The asssignment could not be created or is not active anymore
@@ -788,15 +769,13 @@ components:
         sink: https://application-server.com/callback
         sinkCredential:
           credentialType: ACCESSTOKEN
-          accessToken: "eyJhbGciOiJIUzI1NiIsInR..."
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
-          accessTokenType: bearer
         assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         startedAt: "2024-05-12T17:32:01Z"
         status: UNAVAILABLE
         statusInfo: NETWORK_TERMINATED
 
-    ASSIGNMENT_AVAILABLE_WITHOUT_DEVICE:
+    ASSIGNMENT_AVAILABLE:
       summary: QoS assignment status is available
       description: Device is optional in responses and must not be provided if it was not provided in the request
       value:
@@ -804,9 +783,7 @@ components:
         sink: https://application-server.com/callback
         sinkCredential:
           credentialType: ACCESSTOKEN
-          accessToken: "eyJhbGciOiJIUzI1NiIsInR..."
           accessTokenExpiresUtc: "2024-12-01T12:00:00Z"
-          accessTokenType: bearer
         assignmentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         startedAt: "2024-05-12T17:32:01Z"
         status: AVAILABLE

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -232,7 +232,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SessionInfo"
+                $ref: "#/components/schemas/CreateSessionResponse"
               examples:
                 Example 1:
                   $ref: "#/components/examples/EXAMPLE_1_CREATION_RESPONSE_3-LEGGED_ACCESS_TOKEN_IPv4_SUBNET"
@@ -530,13 +530,6 @@ components:
         Note that the device object is defined as optional and will only to be returned if provided in createSession. If more than one type of device identifier was provided, only one identifier will be returned (at implementation choice and with the original value provided in createSession).
         Please note that IP addresses of devices can change and get reused, so the original values may no longer identify the same device. They identified the device at the time of session creation.
       allOf:
-        - type: object
-          properties:
-            device:
-              description: Disambiguates the device to which the session applies when multiple device identifiers were provided
-              allOf:
-                - $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
-                - example: {"phoneNumber": "+123456789"}
         - $ref: "#/components/schemas/BaseSessionInfo"
         - type: object
           properties:
@@ -599,6 +592,17 @@ components:
               example: 3600
           required:
             - duration
+
+    CreateSessionResponse:
+      description: Session information following successful creation of a session. The `device` property is only required to allow the API consumer to disambiguate the device identifier in the request when more than one identifier is provided.
+        - $ref: "#/components/schemas/BaseSessionInfo"
+        - type: object
+          properties:
+            device:
+              description: Disambiguates the device to which the session applies when multiple device identifiers were provided
+              allOf:
+                - $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
+                - example: {"phoneNumber": "+123456789"}
 
     PortsSpec:
       description: Specification of several TCP or UDP ports

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -595,6 +595,7 @@ components:
 
     CreateSessionResponse:
       description: Session information following successful creation of a session. The `device` property is only required to allow the API consumer to disambiguate the device identifier in the request when more than one identifier is provided.
+      allOf:
         - $ref: "#/components/schemas/BaseSessionInfo"
         - type: object
           properties:

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -594,7 +594,7 @@ components:
             - duration
 
     CreateSessionResponse:
-      description: Session information following successful creation of a session. The `device` property is only required to allow the API consumer to disambiguate the device identifier in the request when more than one identifier is provided.
+        description: Session information plus an optional `device` property, which is only required to allow the API consumer to disambiguate which device identifier applies when more than one identifier is provided in the request.
       allOf:
         - $ref: "#/components/schemas/BaseSessionInfo"
         - type: object
@@ -854,7 +854,16 @@ components:
       description: QoS session information for a given device
       type: array
       items:
-        $ref: "#/components/schemas/SessionInfo"
+        description: Session information plus an optional `device` property, which is only required to allow the API consumer to disambiguate which device identifier applies when more than one identifier is provided in the request.
+        allOf:
+          - $ref: "#/components/schemas/SessionInfo"
+          - type: object
+              properties:
+                device:
+                  description: Disambiguates the device to which the session applies when multiple device identifiers were provided
+                  allOf:
+                    - $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
+                    - example: {"phoneNumber": "+123456789"}
       minItems: 0
       maxItems: 100
 

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -404,8 +404,6 @@ paths:
               examples:
                 SESSION_EXTENDED:
                   $ref: "#/components/examples/SESSION_EXTENDED_EXAMPLE"
-                SESSION_EXTENDED_WITH_DEVICE_RESPONSE:
-                  $ref: "#/components/examples/SESSION_EXTENDED_EXAMPLE_WITH_DEVICE_RESPONSE"
         "400":
           $ref: "#/components/responses/GenericExtendSessionDuration400"
         "401":
@@ -1355,22 +1353,6 @@ components:
       summary: Successful session extension with device not included in response
       description: Example response after the duration of an active QoS session has been extended using a 3-legged access token, or possibly a single device identifier. The session remains AVAILABLE with updated duration and expiresAt values.
       value:
-        applicationServer:
-          ipv4Address: 198.51.100.0/24
-        qosProfile: QOS_L
-        sink: https://application-server.com/notifications
-        sessionId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
-        duration: 5400
-        startedAt: "2024-06-01T12:00:00Z"
-        expiresAt: "2024-06-01T13:30:00Z"
-        qosStatus: AVAILABLE
-
-    SESSION_EXTENDED_EXAMPLE_WITH_DEVICE_RESPONSE:
-      summary: Successful session extension with device included in response
-      description: Example response after the duration of an active QoS session has been extended using a 2-legged access token with multiple device identifiers, or possibly only a single device identifier. The session remains AVAILABLE with updated duration and expiresAt values.
-      value:
-        device:
-          phoneNumber: "+123456789"
         applicationServer:
           ipv4Address: 198.51.100.0/24
         qosProfile: QOS_L

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -594,7 +594,7 @@ components:
             - duration
 
     CreateSessionResponse:
-        description: Session information plus an optional `device` property, which is only required to allow the API consumer to disambiguate which device identifier applies when more than one identifier is provided in the request.
+      description: Session information plus an optional `device` property, which is only required to allow the API consumer to disambiguate which device identifier applies when more than one identifier is provided in the request.
       allOf:
         - $ref: "#/components/schemas/BaseSessionInfo"
         - type: object
@@ -858,12 +858,12 @@ components:
         allOf:
           - $ref: "#/components/schemas/SessionInfo"
           - type: object
-              properties:
-                device:
-                  description: Disambiguates the device to which the session applies when multiple device identifiers were provided
-                  allOf:
-                    - $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
-                    - example: {"phoneNumber": "+123456789"}
+            properties:
+              device:
+                description: Disambiguates the device to which the session applies when multiple device identifiers were provided
+                allOf:
+                  - $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
+                  - example: {"phoneNumber": "+123456789"}
       minItems: 0
       maxItems: 100
 

--- a/code/API_definitions/quality-on-demand.yaml
+++ b/code/API_definitions/quality-on-demand.yaml
@@ -232,7 +232,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreateSessionResponse"
+                $ref: "#/components/schemas/SessionInfoWithDevice"
               examples:
                 Example 1:
                   $ref: "#/components/examples/EXAMPLE_1_CREATION_RESPONSE_3-LEGGED_ACCESS_TOKEN_IPv4_SUBNET"
@@ -572,6 +572,18 @@ components:
             - duration
             - qosStatus
 
+    SessionInfoWithDevice:
+      description: Session information plus an optional `device` property, which is only required to allow the API consumer to disambiguate which device identifier applies when more than one identifier is provided in the request.
+      allOf:
+        - $ref: "#/components/schemas/BaseSessionInfo"
+        - type: object
+          properties:
+            device:
+              description: Disambiguates the device to which the session applies when multiple device identifiers were provided
+              allOf:
+                - $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
+                - example: {"phoneNumber": "+123456789"}
+
     CreateSession:
       description: Attributes required to create a session
       allOf:
@@ -592,18 +604,6 @@ components:
               example: 3600
           required:
             - duration
-
-    CreateSessionResponse:
-      description: Session information plus an optional `device` property, which is only required to allow the API consumer to disambiguate which device identifier applies when more than one identifier is provided in the request.
-      allOf:
-        - $ref: "#/components/schemas/BaseSessionInfo"
-        - type: object
-          properties:
-            device:
-              description: Disambiguates the device to which the session applies when multiple device identifiers were provided
-              allOf:
-                - $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
-                - example: {"phoneNumber": "+123456789"}
 
     PortsSpec:
       description: Specification of several TCP or UDP ports
@@ -854,16 +854,7 @@ components:
       description: QoS session information for a given device
       type: array
       items:
-        description: Session information plus an optional `device` property, which is only required to allow the API consumer to disambiguate which device identifier applies when more than one identifier is provided in the request.
-        allOf:
-          - $ref: "#/components/schemas/SessionInfo"
-          - type: object
-            properties:
-              device:
-                description: Disambiguates the device to which the session applies when multiple device identifiers were provided
-                allOf:
-                  - $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
-                  - example: {"phoneNumber": "+123456789"}
+        $ref: "#/components/schemas/SessionInfoWithDevice"
       minItems: 0
       maxItems: 100
 


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
The PR:
- removes the optional `device` property from the `SessionInfo` and `AssignmentInfo` schemas, and creates new schemas `SessionInfoWithDevice` and `AssignmentInfoWithDevice` for use when device disambiguation may be required
- fixes response examples

The `SessionInfo` and `AssignmentInfo` schema are used as the response body for endpoints where there is no requirement to return a `device` identifier.

The `SessionInfoWithDevice` and `AssignmentInfoWithDevice` schema are used as the response body for endpoints where there may be a requirement to return a `device` identifier.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #596 

#### Special notes for reviewers:
The `SessionInfo` and `AssignmentInfo` schemas and can be used by implementations as the session / assignment record if there is no need for the implementation to explicitly record the device identifier.

If the implementation requires to store a device identifier (independent of how the device was identified), then the `SessionInfoWithDevice` and `AssignmentInfoWithDevice` can be used so long as the implementation is disciplined enough not to include `device` in responses where it is never required.

This is not a breaking change for the client, as the PR only removes the possibility to return what is currently an optional parameter for some endpoints.

#### Changelog input
```
 release-note
 - Remove device property from SessionInfo and Assignment Info
```

#### Additional documentation 
None