### PR TITLE
Change maximum value for duration to 999 for QoS profiles

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -426,7 +426,7 @@ components:
           example: 12
           format: int32
           minimum: 1
-          maximum: 2147483647
+          maximum: 999
         unit:
           $ref: "#/components/schemas/TimeUnitEnum"
 


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
This PR sets the maximum value of a duration to 999 time units

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #601 

#### Special notes for reviewers:
This should not considered to be a breaking change, albeit that the expression of time units for some existing profiles might have to be expressed in a different form (e.g. 1000 Milliseconds becomes 1 Second).

#### Changelog input

```
 release-note
 - Change maximum value for duration to 999 for QoS profiles
```

#### Additional documentation 
None