### PR TITLE
fix(qos-profiles): correct HomeDevicesQoQ and DCSP typos

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -350,7 +350,7 @@ components:
 
             **NOTE**: serviceClass is experimental and could change or be removed in a future release.
 
-            The name of a Service Class, representing a QoS Profile designed to provide optimized behavior for a specific application type. While DSCP values are commonly associated with Service Classes, their use may vary across network segments and may not be applied throughout the entire end-to-end QoS session. This aligns with the serviceClass concept used in HomeDevicesQoQ for consistent terminology.
+            The name of a Service Class, representing a QoS Profile designed to provide optimized behavior for a specific application type. While DSCP values are commonly associated with Service Classes, their use may vary across network segments and may not be applied throughout the entire end-to-end QoS session. This aligns with the serviceClass concept used in HomeDevicesQoD for consistent terminology.
 
             Service classes define specific QoS behaviors that map to DSCP (Differentiated Services Code Point) values or Microsoft QoS traffic types.
 
@@ -360,7 +360,7 @@ components:
 
             **Supported Service Classes**:
 
-            | Service Class Name    | DSCP Name | DSCP value (decimal) | DCSP value (binary) | Microsoft Value | Application Examples                                                 |
+            | Service Class Name    | DSCP Name | DSCP value (decimal) | DSCP value (binary) | Microsoft Value | Application Examples                                                 |
             |-----------------------|-----------|----------------------|---------------------|-----------------|----------------------------------------------------------------------|
             | Microsoft Voice       |    CS7    |          56          |        111000       |       4,5       | Microsoft QOSTrafficTypeVoice and QOSTrafficTypeControl              |
             | Microsoft Audio/Video |    CS5    |          40          |        101000       |       2,3       | Microsoft QOSTrafficTypeExcellentEffort and QOSTrafficTypeAudioVideo |


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Fixes two spelling errors in the `serviceClass` documentation of `code/API_definitions/qos-profiles.yaml`, as reported in #603:

- `HomeDevicesQoQ` → `HomeDevicesQoD` — the actual name of the CAMARA API being referenced ([camaraproject/HomeDevicesQoD](https://github.com/camaraproject/HomeDevicesQoD)).
- `DCSP value (binary)` → `DSCP value (binary)` in the **Supported Service Classes** table header, matching the adjacent `DSCP value (decimal)` column and the DSCP spelling used everywhere else in the file.

Documentation only — no functional or API contract change.

#### Which issue(s) this PR fixes:

Partially addresses #603

<!-- Not using "Fixes" because #603 also reports terminology inconsistencies
("API Consumer" vs "API consumer", "3-legged" vs "three-legged access token")
which are left for a separate change so this PR stays a pure typo fix. -->

#### Special notes for reviewers:

This is my first contribution to CAMARA — happy to adjust anything (scope, wording, commit style) to match project conventions.

The remaining items in #603 (capitalisation of "API Consumer" and "3-legged" vs "three-legged access token") are intentionally left out of this PR so the diff stays limited to unambiguous typos. Glad to open a follow-up for those if maintainers would like them addressed the same way.

#### Changelog input

```
 release-note
Corrected typos in qos-profiles.yaml serviceClass documentation: HomeDevicesQoQ -> HomeDevicesQoD and DCSP -> DSCP.
```

#### Additional documentation

This section can be blank.

```
docs

```
