### PR TITLE
[Fixed] Fix country code standard reference in qos-profiles.yaml

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -487,7 +487,7 @@ components:
           - countryName
         properties:
           countryName:
-            description: The two letter ISO 3166-2 country code for the country in which the QoS profile is available in at least one network
+            description: The two letter ISO 3166-1 alpha-2 country code for the country in which the QoS profile is available in at least one network
             type: string
             pattern: ^[A-Z]{2}$
             maxLength: 2


### PR DESCRIPTION
#### What type of PR is this?
* correction
* documentation

#### What this PR does / why we need it:
Corrects ISO code reference from '3166-2' to '3166-1 alpha-2'.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #604 

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Fix country code reference in qos-profiles.yaml
```

#### Additional documentation 
None