### PR TITLE
fix(qos-profiles): remove HomeDeviceQoD reference, fix DCSP typo (#603)

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -350,7 +350,7 @@ components:
 
             **NOTE**: serviceClass is experimental and could change or be removed in a future release.
 
-            The name of a Service Class, representing a QoS Profile designed to provide optimized behavior for a specific application type. While DSCP values are commonly associated with Service Classes, their use may vary across network segments and may not be applied throughout the entire end-to-end QoS session. This aligns with the serviceClass concept used in HomeDevicesQoQ for consistent terminology.
+            The name of a Service Class, representing a QoS Profile designed to provide optimized behavior for a specific application type. While DSCP values are commonly associated with Service Classes, their use may vary across network segments and may not be applied throughout the entire end-to-end QoS session.
 
             Service classes define specific QoS behaviors that map to DSCP (Differentiated Services Code Point) values or Microsoft QoS traffic types.
 
@@ -360,7 +360,7 @@ components:
 
             **Supported Service Classes**:
 
-            | Service Class Name    | DSCP Name | DSCP value (decimal) | DCSP value (binary) | Microsoft Value | Application Examples                                                 |
+            | Service Class Name    | DSCP Name | DSCP value (decimal) | DSCP value (binary) | Microsoft Value | Application Examples                                                 |
             |-----------------------|-----------|----------------------|---------------------|-----------------|----------------------------------------------------------------------|
             | Microsoft Voice       |    CS7    |          56          |        111000       |       4,5       | Microsoft QOSTrafficTypeVoice and QOSTrafficTypeControl              |
             | Microsoft Audio/Video |    CS5    |          40          |        101000       |       2,3       | Microsoft QOSTrafficTypeExcellentEffort and QOSTrafficTypeAudioVideo |


### PR DESCRIPTION

#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Fixes two spelling errors in the `serviceClass` documentation of `code/API_definitions/qos-profiles.yaml`, as reported in #603:

- Removed the "This aligns with the serviceClass concept used in HomeDevicesQoQ for consistent terminology" sentence. It had a typo (`HomeDevicesQoQ`), and per discussion on #603 the reference itself is being dropped rather than corrected to `HomeDevicesQoD`, since that API is archived.
- `DCSP value (binary)` → `DSCP value (binary)`

Documentation only — no functional or API contract change.

The remaining items reported in #603 ("API Consumer"/"API consumer" capitalisation, "3-legged"/"three-legged access token" wording) are left out of this PR. The capitalised form only appears in shared Commonalities common-schema files, out of scope for this repo, and the "3-legged"/"three-legged" mix matches the CAMARA API Design Guide's own usage (word form in prose, numeral form in tables/bullets), so it isn't an inconsistency to fix here.

#### Which issue(s) this PR fixes:

Fixes #603

#### Special notes for reviewers:

Supersedes #606, which proposed renaming the reference to `HomeDevicesQoD` instead of removing it — the issue discussion since then settled on removal.

#### Changelog input

```
 release-note
Corrected typos in qos-profiles.yaml serviceClass documentation: removed the archived HomeDeviceQoD reference and fixed DCSP -> DSCP.
```

#### Additional documentation

This section can be blank.

```
docs

```
