### PR TITLE
fix(qos-profiles): rename operationId retrieveQoSProfiles to retrieveQosProfiles

### DIFF
--- a/code/API_definitions/qos-profiles.yaml
+++ b/code/API_definitions/qos-profiles.yaml
@@ -30,9 +30,9 @@ info:
 
     # Identifying the device from the access token
 
-    The two operations defined by this API (`getQosProfile` and `retrieveQoSProfiles`) both allow the API consumer to use a three-legged access token to specify a target device as a query filter. When provided, only profiles available to the specified target device will be returned. Additionally, when a two-legged access token is used, the operation `retrieveQoSProfiles` allows the API consumer to optionally specify the target device in the request body.
+    The two operations defined by this API (`getQosProfile` and `retrieveQosProfiles`) both allow the API consumer to use a three-legged access token to specify a target device as a query filter. When provided, only profiles available to the specified target device will be returned. Additionally, when a two-legged access token is used, the operation `retrieveQosProfiles` allows the API consumer to optionally specify the target device in the request body.
 
-    Hence, for the `retrieveQoSProfiles` operation:
+    Hence, for the `retrieveQosProfiles` operation:
     - When invoked using a two-legged access token, the optional input device object will be used as filter if present.
 
     - When invoked using a three-legged access token, this optional identifier in the request body MUST NOT be provided, as the device to filter will be uniquely identified from the access token.
@@ -107,7 +107,7 @@ paths:
       security:
         - openId:
             - qos-profiles:read
-      operationId: retrieveQoSProfiles
+      operationId: retrieveQosProfiles
       parameters:
         - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       requestBody:

--- a/code/Test_definitions/qos-profiles-retrieveQosProfiles.feature
+++ b/code/Test_definitions/qos-profiles-retrieveQosProfiles.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
+Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQosProfiles
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -15,7 +15,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
   # unless the path points to "../common/CAMARA_common.yaml", in which case the
   # schema is the one synced from CAMARA Commonalities.
 
-  Background: Common retrieveQoSProfiles setup
+  Background: Common retrieveQosProfiles setup
     Given an environment at "apiRoot"
     And the resource "/qos-profiles/vwip/retrieve-qos-profiles"
     And the header "Content-Type" is set to "application/json"
@@ -26,33 +26,33 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
 
   ############################ Happy Path Scenarios #############################################
 
-  @qos_profiles_retrieveQoSProfiles_01_generic_success_scenario
+  @qos_profiles_retrieveQosProfiles_01_generic_success_scenario
   Scenario: Common validations for any success scenario
     # Valid testing device and default request body compliant with the schema
     Given a request body compliant with the schema at "/components/schemas/QosProfileDeviceRequest"
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And each item of the response array, if any, complies with the OAS schema at "/components/schemas/QosProfile"
     # TBC: Add additional constraints, such as max* properties must be higher than min* equivalent properties, etc
 
-  @qos_profiles_retrieveQoSProfiles_02_filter_by_name_only
+  @qos_profiles_retrieveQosProfiles_02_filter_by_name_only
   Scenario: Retrieve QoS profiles only by name
     Given the request body property "$.name" is set to an existing QoS profile name
     And the request body properties "$.device" and "$.status" are not included
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response array has only one item which complies with the OAS schema at "/components/schemas/QosProfile"
     And the response property "$[0].name" value is equal to the request body property "$.name"
 
-  @qos_profiles_retrieveQoSProfiles_03_filter_by_status_only
+  @qos_profiles_retrieveQosProfiles_03_filter_by_status_only
   Scenario Outline: Retrieve QoS profiles only by status
     Given the request body property "$.status" is set to the value <status>
     And the request body properties "$.device" and "$.name" are not included
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -65,34 +65,34 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
       | INACTIVE   |
       | DEPRECATED |
 
-  @qos_profiles_retrieveQoSProfiles_04_return_restricted_profiles
+  @qos_profiles_retrieveQosProfiles_04_return_restricted_profiles
   Scenario: Return QoS Profiles restricted to certain devices
     Given that implementation has QoS Profiles restricted to certain devices
     And a device suitable for the restricted QoS Profiles is provided in the request body or identified by the access token
     And the request body properties "$.name" and "$.status" are not included
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And each item of the response array complies with the OAS schema at "/components/schemas/QosProfile"
     And the restricted QoS Profiles are returned in the response
 
-  @qos_profiles_retrieveQoSProfiles_05_not_return_restricted_profiles
+  @qos_profiles_retrieveQosProfiles_05_not_return_restricted_profiles
   Scenario: Do not return restricted QoS Profiles restricted to certain devices
     Given that implementation has QoS Profiles restricted to certain devices
     And no device is provided in the request body or identified by the access token
     And the request body properties "$.name" and "$.status" are not included
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And each item of the response array complies with the OAS schema at "/components/schemas/QosProfile"
     And no restricted QoS Profile is included in the response
 
-  @qos_profiles_retrieveQoSProfiles_06_device_qos_profiles_not_found
+  @qos_profiles_retrieveQosProfiles_06_device_qos_profiles_not_found
   Scenario: Device has no QoS profiles associated
     Given a device for which the service is not applicable, provided in the request body or identified by the access token
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -102,7 +102,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
 
   # Error scenarios for management of input parameter device (C01)
 
-  @qos_profiles_retrieveQoSProfiles_C01.01_device_empty
+  @qos_profiles_retrieveQosProfiles_C01.01_device_empty
   Scenario: The device value is an empty object
     Given the header "Authorization" is set to a valid access token which does not identify a single device
     And the request body property "$.device" is set to: {}
@@ -114,7 +114,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @qos_profiles_retrieveQoSProfiles_C01.02_device_identifiers_not_schema_compliant
+  @qos_profiles_retrieveQosProfiles_C01.02_device_identifiers_not_schema_compliant
   Scenario Outline: Some device identifier value does not comply with the schema
     Given the header "Authorization" is set to a valid access token which does not identify a single device
     And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
@@ -134,7 +134,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
       | $.device.networkAccessIdentifier | ../common/CAMARA_common.yaml#/components/schemas/NetworkAccessIdentifier |
 
   # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.
-  @qos_profiles_retrieveQoSProfiles_C01.03_device_not_found
+  @qos_profiles_retrieveQosProfiles_C01.03_device_not_found
   Scenario: Some identifier cannot be matched to a device
     Given the header "Authorization" is set to a valid access token which does not identify a single device
     And the request body property "$.device" is compliant with the schema but does not identify a valid device
@@ -146,7 +146,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
     And the response property "$.message" contains a user friendly text
 
-  @qos_profiles_retrieveQoSProfiles_C01.04_unnecessary_device
+  @qos_profiles_retrieveQosProfiles_C01.04_unnecessary_device
   Scenario: Device not to be included when it can be deduced from the access token
     Given the header "Authorization" is set to a valid access token identifying a device
     And the request body property "$.device" is set to a valid device
@@ -158,7 +158,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
     And the response property "$.message" contains a user-friendly text
 
-  @qos_profiles_retrieveQoSProfiles_C01.06_unsupported_device
+  @qos_profiles_retrieveQosProfiles_C01.06_unsupported_device
   Scenario: None of the provided device identifiers is supported by the implementation
     Given that some types of device identifiers are not supported by the implementation
     And the header "Authorization" is set to a valid access token which does not identify a single device
@@ -172,7 +172,7 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the response property "$.message" contains a user-friendly text
 
   # When the service is only offered to certain types of devices or subscriptions, e.g. IoT, B2C, etc.
-  @qos_profiles_retrieveQoSProfiles_C01.07_device_not_supported
+  @qos_profiles_retrieveQosProfiles_C01.07_device_not_supported
   Scenario: Service not available for the device
     Given that the service is not available for all devices commercialized by the operator
     And a valid device, identified by the token or provided in the request body, for which the service is not applicable
@@ -186,10 +186,10 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
 
   # Syntax Error scenarios
 
-  @qos_profiles_retrieveQoSProfiles_400.01_schema_not_compliant
+  @qos_profiles_retrieveQosProfiles_400.01_schema_not_compliant
   Scenario: Invalid Argument. Generic Syntax Exception
     Given the request body is set to any value which is not compliant with the schema at "/components/schemas/QosProfileDeviceRequest"
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -197,10 +197,10 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @qos_profiles_retrieveQoSProfiles_400.02_no_request_body
+  @qos_profiles_retrieveQosProfiles_400.02_no_request_body
   Scenario: Missing request body
     Given the request body is not included
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -212,10 +212,10 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
   # QosProfileDeviceRequest has no required properties, so an empty object is a
   # valid request returning all profiles (see scenario 05_not_return_restricted_profiles)
 
-  @qos_profiles_retrieveQoSProfiles_400.03_invalid_x-correlator
+  @qos_profiles_retrieveQosProfiles_400.03_invalid_x-correlator
   Scenario: Invalid x-correlator header
     Given the header "x-correlator" does not comply with the schema at "../common/CAMARA_common.yaml#/components/schemas/XCorrelator"
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
@@ -227,11 +227,11 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
 
   # Generic 401 errors
 
-  @qos_profiles_retrieveQoSProfiles_401.01_no_authorization_header
+  @qos_profiles_retrieveQosProfiles_401.01_no_authorization_header
   Scenario: Error response for no header "Authorization"
     Given the header "Authorization" is not sent
     And the request body is set to a valid request body
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 401
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -240,11 +240,11 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the response property "$.message" contains a user friendly text
 
   # In this case both codes could make sense depending on whether the access token can be refreshed or not
-  @qos_profiles_retrieveQoSProfiles_401.02_expired_access_token
+  @qos_profiles_retrieveQosProfiles_401.02_expired_access_token
   Scenario: Error response for expired access token
     Given the header "Authorization" is set to an expired access token
     And the request body is set to a valid request body
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 401
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -252,11 +252,11 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @qos_profiles_retrieveQoSProfiles_401.03_invalid_access_token
+  @qos_profiles_retrieveQosProfiles_401.03_invalid_access_token
   Scenario: Error response for invalid access token
     Given the header "Authorization" is set to an invalid access token
     And the request body is set to a valid request body
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 401
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -266,10 +266,10 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
 
   # Generic 403 errors
 
-  @qos_profiles_retrieveQoSProfiles_403.01_missing_access_token_scope
+  @qos_profiles_retrieveQosProfiles_403.01_missing_access_token_scope
   Scenario: Missing access token scope
     Given the header "Authorization" is set to an access token that does not include scope "qos-profiles:read"
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -279,13 +279,13 @@ Feature: CAMARA QoS Profiles API, vwip - Operation retrieveQoSProfiles
 
   # Generic 429 errors
 
-  @qos_profiles_retrieveQoSProfiles_429.01_too_many_requests
+  @qos_profiles_retrieveQosProfiles_429.01_too_many_requests
   # To test this scenario the environment has to be configured to reject requests reaching the threshold limit set.
   Scenario: Request is rejected due to threshold policy
-    Given a valid request for "retrieveQoSProfiles"
+    Given a valid request for "retrieveQosProfiles"
     And the header "Authorization" is set to a valid access token
     And the threshold of requests has been reached
-    When the request "retrieveQoSProfiles" is sent
+    When the request "retrieveQosProfiles" is sent
     Then the response status code is 429
     And the response property "$.status" is 429
     And the response property "$.code" is "TOO_MANY_REQUESTS"


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Renames the operationId `retrieveQoSProfiles` to `retrieveQosProfiles` in `code/API_definitions/qos-profiles.yaml`. It was the only operationId in this repository spelling the token `QoS` — the other seven use `Qos`, as do the schema names and the `RetrieveQosProfilesNotFound404` response in the same file. CAMARA Validation has reported it as a non-blocking `S-007` hint since r3.2.

Also updated: the three backticked references to the operationId in `info.description`, and the test definitions (file renamed to `qos-profiles-retrieveQosProfiles.feature`, with its feature title, background, scenario tags and step names).

`operationId` is not part of the HTTP contract and appears in neither compatibility list of the API Design Guide. The rename was agreed as non-breaking on the 2026-08-07 call. Prose wording and the `QoS Profiles` tag keep `QoS` — this is identifiers only.

#### Which issue(s) this PR fixes:

Fixes #590

#### Special notes for reviewers:

The r4.1 changelog entry mentioning `retrieveQoSProfiles` is left unchanged, as it records what shipped in that release.

#### Changelog input

```
 release-note
Renamed operationId `retrieveQoSProfiles` to `retrieveQosProfiles` for consistency with the other operationIds and schema names. Non-breaking: operationId is not part of the HTTP contract.
```

#### Additional documentation

This section can be blank.

```
docs

```
