### PR TITLE
chore(release-plan): bump to r4.2, remove qos-profiles

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -32,14 +32,6 @@ dependencies:
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)
 # - target_api_status: draft (no file yet) | alpha | rc | public
 apis:
-  - api_name: qos-profiles
-    target_api_version: 1.2.0
-    target_api_status: rc
-    main_contacts:
-      - hdamker
-      - eric-murray
-      - benhepworth
-      - jlurien
   - api_name: qos-provisioning
     target_api_version: 0.4.0
     target_api_status: rc

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,7 +16,7 @@ repository:
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r4.1
+  target_release_tag: r4.2
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.3
+  commonalities_release: r4.4
   identity_consent_management_release: r4.2
 
 # APIs in this repository


### PR DESCRIPTION

#### What type of PR is this?

subproject management

#### What this PR does / why we need it:

Removes `qos-profiles` from `release-plan.yaml` — the API has moved to the new camaraproject/QoSProfiles repository — and bumps the release plan to the next cycle (`r4.2`, Commonalities `r4.4`), since `r4.1` is already published and CAMARA Validation (P-035) blocks editing a published release's API list.

#### Which issue(s) this PR fixes:

Part of #568

#### Special notes for reviewers:

A companion PR (#615) removes the seeded `qos-profiles` API/test definitions and updates the README.

#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
